### PR TITLE
DT-2054 Delegate to probation for recall reason when NOMIS thinks it is a sentence

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/offenderevents/services/CommunityApiService.java
+++ b/src/main/java/uk/gov/justice/hmpps/offenderevents/services/CommunityApiService.java
@@ -54,6 +54,6 @@ record NsiWrapper(List<Recall> nsis) {
 
 }
 
-record Recall(LocalDate referralDate) {
+record Recall(LocalDate referralDate, Boolean recallRejectedOrWithdrawn, Boolean outcomeRecall) {
 
 }

--- a/src/main/java/uk/gov/justice/hmpps/offenderevents/services/ReceivePrisonerReasonCalculator.java
+++ b/src/main/java/uk/gov/justice/hmpps/offenderevents/services/ReceivePrisonerReasonCalculator.java
@@ -2,12 +2,16 @@ package uk.gov.justice.hmpps.offenderevents.services;
 
 import org.springframework.stereotype.Component;
 
+import java.util.Optional;
+
 @Component
 public class ReceivePrisonerReasonCalculator {
     private final PrisonApiService prisonApiService;
+    private final CommunityApiService communityApiService;
 
-    public ReceivePrisonerReasonCalculator(PrisonApiService prisonApiService) {
+    public ReceivePrisonerReasonCalculator(PrisonApiService prisonApiService, CommunityApiService communityApiService) {
         this.prisonApiService = prisonApiService;
+        this.communityApiService = communityApiService;
     }
 
     public Reason calculateReasonForPrisoner(String offenderNumber) {
@@ -20,13 +24,36 @@ public class ReceivePrisonerReasonCalculator {
             return Reason.RECALL;
         }
 
-        return switch (prisonerDetails.legalStatus()) {
+        final Optional<Reason> maybeRecallStatusFromProbation = switch (prisonerDetails.legalStatus()) {
+            case OTHER, UNKNOWN, CONVICTED_UNSENTENCED, SENTENCED, INDETERMINATE_SENTENCE -> calculateReasonForPrisonerFromProbation(offenderNumber);
+            default -> Optional.empty();
+        };
+
+        return maybeRecallStatusFromProbation.orElseGet(() -> switch (prisonerDetails.legalStatus()) {
             case RECALL -> Reason.RECALL;
             case CIVIL_PRISONER, CONVICTED_UNSENTENCED, SENTENCED, INDETERMINATE_SENTENCE -> Reason.CONVICTED;
             case IMMIGRATION_DETAINEE -> Reason.IMMIGRATION_DETAINEE;
             case REMAND -> Reason.REMAND;
             case DEAD, OTHER, UNKNOWN -> Reason.UNKNOWN;
-        };
+        });
+    }
+
+    private Optional<Reason> calculateReasonForPrisonerFromProbation(String offenderNumber) {
+        final var maybeRecallList = communityApiService.getRecalls(offenderNumber);
+        return maybeRecallList
+            .filter(recalls -> recalls.stream().anyMatch(this::hasActiveOrCompletedRecall))
+            .map(recalls -> Reason.RECALL);
+    }
+
+    private boolean hasActiveOrCompletedRecall(Recall recall) {
+        if (recall.outcomeRecall() != null) {
+            return recall.outcomeRecall();
+        }
+
+        if (recall.recallRejectedOrWithdrawn() != null) {
+            return !recall.recallRejectedOrWithdrawn();
+        }
+        return false;
     }
 
     enum Reason {

--- a/src/test/java/uk/gov/justice/hmpps/offenderevents/e2e/HMPPSDomainEventsTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/offenderevents/e2e/HMPPSDomainEventsTest.java
@@ -153,7 +153,6 @@ public class HMPPSDomainEventsTest {
 
             @Test
             @DisplayName("will publish prison-offender-events.prisoner.received HMPPS domain event by asking community-api")
-            @Disabled("waiting for implementation")
             void willPublishHMPPSDomainEvent() {
                 await().until(() -> getNumberOfMessagesCurrentlyOnQueue(HMPPS_DOMAIN_EVENTS_SUBSCRIBE_QUEUE_NAME) == 1);
                 final var hmppsEventMessages = geMessagesCurrentlyOnQueue(HMPPS_DOMAIN_EVENTS_SUBSCRIBE_QUEUE_NAME);
@@ -162,7 +161,21 @@ public class HMPPSDomainEventsTest {
                     assertThatJson(event).node("additionalInformation.reason").isEqualTo("CONVICTED");
                 });
 
-                CommunityApiExtension.server.verify(getRequestedFor(WireMock.urlEqualTo("/secure/offenders/nomsNumber/A7841DY/convictions/active/nsis/recall")));
+                CommunityApiExtension.server.verify(getRequestedFor(WireMock.urlEqualTo("/secure/offenders/nomsNumber/A5194DY/convictions/active/nsis/recall")));
+            }
+            @Test
+            @DisplayName("will publish a recalled  prison-offender-events.prisoner.received HMPPS domain event when community-api indicates a recall")
+            void willPublishRecallHMPPSDomainEvent() {
+                CommunityApiExtension.server.stubForRecall("A5194DY");
+
+                await().until(() -> getNumberOfMessagesCurrentlyOnQueue(HMPPS_DOMAIN_EVENTS_SUBSCRIBE_QUEUE_NAME) == 1);
+                final var hmppsEventMessages = geMessagesCurrentlyOnQueue(HMPPS_DOMAIN_EVENTS_SUBSCRIBE_QUEUE_NAME);
+                assertThat(hmppsEventMessages).singleElement().satisfies(event -> {
+                    assertThatJson(event).node("eventType").isEqualTo("prison-offender-events.prisoner.received");
+                    assertThatJson(event).node("additionalInformation.reason").isEqualTo("RECALL");
+                });
+
+                CommunityApiExtension.server.verify(getRequestedFor(WireMock.urlEqualTo("/secure/offenders/nomsNumber/A5194DY/convictions/active/nsis/recall")));
             }
         }
     }

--- a/src/test/java/uk/gov/justice/hmpps/offenderevents/services/CommunityApiServiceTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/offenderevents/services/CommunityApiServiceTest.java
@@ -76,6 +76,24 @@ class CommunityApiServiceTest {
                 assertThat(recalls.get(0).referralDate()).isEqualTo("2021-05-12");
                 assertThat(recalls.get(1).referralDate()).isEqualTo("2021-05-13");
             }
+
+            @Test
+            @DisplayName("can parse the recallRejectedOrWithdrawn")
+            void canParseRecallRejectedOrWithdrawn() {
+                final var recalls = service.getRecalls("A7841DY").orElseThrow();
+
+                assertThat(recalls.get(0).recallRejectedOrWithdrawn()).isTrue();
+                assertThat(recalls.get(1).recallRejectedOrWithdrawn()).isFalse();
+            }
+
+            @Test
+            @DisplayName("can parse the outcomeRecall")
+            void canParseOutcomeRecall() {
+                final var recalls = service.getRecalls("A7841DY").orElseThrow();
+
+                assertThat(recalls.get(1).outcomeRecall()).isNull();
+                assertThat(recalls.get(0).outcomeRecall()).isFalse();
+            }
         }
     }
 }

--- a/src/test/java/uk/gov/justice/hmpps/offenderevents/services/wiremock/CommunityApiMockServer.java
+++ b/src/test/java/uk/gov/justice/hmpps/offenderevents/services/wiremock/CommunityApiMockServer.java
@@ -115,7 +115,9 @@ public class CommunityApiMockServer extends WireMockServer {
                                 "description": "National Probation Service"
                             }
                         },
-                        "active": true
+                        "active": true,
+                        "recallRejectedOrWithdrawn": true,
+                        "outcomeRecall": false
                     },
                     {
                         "nsiId": 2500032227,
@@ -211,7 +213,8 @@ public class CommunityApiMockServer extends WireMockServer {
                                 "description": "National Probation Service"
                             }
                         },
-                        "active": false
+                        "active": false,
+                        "recallRejectedOrWithdrawn": false
                     }
                 ]
             }


### PR DESCRIPTION
The problem trying to solve is this scenario:

1) Prisoner is booked into prison
2) Admin has booked them with legal status of SENTENCED 
3) the Prisoner's status is therefore not RECALLED 
4) Probation has raised a recall request that has not been rejected
5) Therefore was can assume the prison booking is a RECALL despite at point of entry NOMIS not recording it as a recall

Further more there are other data entry oddities:
Probation don't always correctly enter a NSI (recall) outcome even do PPU has issued a warrant. So we have to assume so longer as the recall has not been rejected a warrant was issued.
