### PR TITLE
Dt 2054 hmpps domain events

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,10 @@ Results in:
 ```bash
 aws --endpoint-url=http://localhost:4576 sqs receive-message --queue-url http://localhost:4576/queue/event_queue
 ```
+
+## Running tests
+The integration tests depend on localstack to be running to access the topics and test queues, this can be started with docker-compose
+
+```bash
+docker-compose -f docker-compose-test.yml
+```

--- a/src/main/java/uk/gov/justice/hmpps/offenderevents/services/HMPPSDomainEventsEmitter.java
+++ b/src/main/java/uk/gov/justice/hmpps/offenderevents/services/HMPPSDomainEventsEmitter.java
@@ -65,10 +65,15 @@ public class HMPPSDomainEventsEmitter {
 
     private HMPPSDomainEvent toPrisonerReceived(OffenderEvent event) {
         final var offenderNumber = event.getOffenderIdDisplay();
-        return new HMPPSDomainEvent("prison-offender-events.prisoner.received", new AdditionalInformation(offenderNumber, receivePrisonerReasonCalculator
-            .calculateReasonForPrisoner(offenderNumber)
-            .name()), event
-            .getEventDatetime(), "A prisoner has been received into prison");
+        final var receivedReason  =  receivePrisonerReasonCalculator.calculateReasonForPrisoner(offenderNumber);
+        return new HMPPSDomainEvent("prison-offender-events.prisoner.received",
+            new AdditionalInformation(offenderNumber,
+                receivedReason.reason().name(),
+                receivedReason.source().name(),
+                receivedReason.details()
+            ),
+            event.getEventDatetime(),
+            "A prisoner has been received into prison");
     }
 
     private HMPPSDomainEvent toPrisonerReleased(OffenderEvent event) {
@@ -106,5 +111,8 @@ record HMPPSDomainEvent(String eventType, AdditionalInformation additionalInform
     }
 }
 
-record AdditionalInformation(String nomsNumber, String reason) {
+record AdditionalInformation(String nomsNumber, String reason, String source, String details) {
+    AdditionalInformation(String nomsNumber, String reason) {
+        this(nomsNumber, reason, null, null);
+    }
 }

--- a/src/main/java/uk/gov/justice/hmpps/offenderevents/services/HMPPSDomainEventsEmitter.java
+++ b/src/main/java/uk/gov/justice/hmpps/offenderevents/services/HMPPSDomainEventsEmitter.java
@@ -65,7 +65,7 @@ public class HMPPSDomainEventsEmitter {
 
     private HMPPSDomainEvent toPrisonerReceived(OffenderEvent event) {
         final var offenderNumber = event.getOffenderIdDisplay();
-        final var receivedReason  =  receivePrisonerReasonCalculator.calculateReasonForPrisoner(offenderNumber);
+        final var receivedReason  =  receivePrisonerReasonCalculator.calculateMostLikelyReasonForPrisoner(offenderNumber);
         return new HMPPSDomainEvent("prison-offender-events.prisoner.received",
             new AdditionalInformation(offenderNumber,
                 receivedReason.reason().name(),

--- a/src/main/java/uk/gov/justice/hmpps/offenderevents/services/ReceivePrisonerReasonCalculator.java
+++ b/src/main/java/uk/gov/justice/hmpps/offenderevents/services/ReceivePrisonerReasonCalculator.java
@@ -17,7 +17,7 @@ public class ReceivePrisonerReasonCalculator {
         this.communityApiService = communityApiService;
     }
 
-    public RecallReason calculateReasonForPrisoner(String offenderNumber) {
+    public RecallReason calculateMostLikelyReasonForPrisoner(String offenderNumber) {
         final var prisonerDetails = prisonApiService.getPrisonerDetails(offenderNumber);
 
         if (prisonerDetails.typeOfMovement() == MovementType.TEMPORARY_ABSENCE_RETURN) {
@@ -28,7 +28,7 @@ public class ReceivePrisonerReasonCalculator {
         }
 
         final Optional<RecallReason> maybeRecallStatusFromProbation = switch (prisonerDetails.legalStatus()) {
-            case OTHER, UNKNOWN, CONVICTED_UNSENTENCED, SENTENCED, INDETERMINATE_SENTENCE -> calculateReasonForPrisonerFromProbation(offenderNumber);
+            case OTHER, UNKNOWN, CONVICTED_UNSENTENCED, SENTENCED, INDETERMINATE_SENTENCE -> calculateReasonForPrisonerFromProbationOrEmpty(offenderNumber);
             default -> Optional.empty();
         };
 
@@ -44,7 +44,7 @@ public class ReceivePrisonerReasonCalculator {
         });
     }
 
-    private Optional<RecallReason> calculateReasonForPrisonerFromProbation(String offenderNumber) {
+    private Optional<RecallReason> calculateReasonForPrisonerFromProbationOrEmpty(String offenderNumber) {
         final var maybeRecallList = communityApiService.getRecalls(offenderNumber);
         return maybeRecallList
             .filter(recalls -> recalls.stream().anyMatch(this::hasActiveOrCompletedRecall))

--- a/src/main/resources/swagger-description.html
+++ b/src/main/resources/swagger-description.html
@@ -61,6 +61,14 @@
                     <li><b>UNKNOWN</b> prisoner's legal status is unknown at this time so reason for booking is unknown </li>
                   </ul>
                 </li>
+                <li><b>source</b> enum - the primary source system that has determined the reason. Will be one of these values
+                  <ul>
+                    <li><b>PRISON</b> the typical case that the prison system (NOMIS) was used to calculate the reason</li>
+                    <li><b>PROBATION</b> when the probation system (Delius) has an outstanding recall request which has not been recorded in NOMIS yet </li>
+                  </ul>
+                </li>
+                <li><b>detail</b> string - further human readable information about the reason. Example <b>Recall referral date 2021-06-13</b>
+                </li>
               </ul>
             </li>
           </ul>

--- a/src/test/java/uk/gov/justice/hmpps/offenderevents/e2e/HMPPSDomainEventsTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/offenderevents/e2e/HMPPSDomainEventsTest.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import junit.framework.AssertionFailedError;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/uk/gov/justice/hmpps/offenderevents/e2e/HMPPSDomainEventsTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/offenderevents/e2e/HMPPSDomainEventsTest.java
@@ -138,6 +138,7 @@ public class HMPPSDomainEventsTest {
                 assertThat(hmppsEventMessages).singleElement().satisfies(event -> {
                     assertThatJson(event).node("eventType").isEqualTo("prison-offender-events.prisoner.received");
                     assertThatJson(event).node("additionalInformation.reason").isEqualTo("RECALL");
+                    assertThatJson(event).node("additionalInformation.source").isEqualTo("PRISON");
                 });
 
                 CommunityApiExtension.server.verify(0, getRequestedFor(anyUrl()));
@@ -159,6 +160,7 @@ public class HMPPSDomainEventsTest {
                 assertThat(hmppsEventMessages).singleElement().satisfies(event -> {
                     assertThatJson(event).node("eventType").isEqualTo("prison-offender-events.prisoner.received");
                     assertThatJson(event).node("additionalInformation.reason").isEqualTo("CONVICTED");
+                    assertThatJson(event).node("additionalInformation.source").isEqualTo("PRISON");
                 });
 
                 CommunityApiExtension.server.verify(getRequestedFor(WireMock.urlEqualTo("/secure/offenders/nomsNumber/A5194DY/convictions/active/nsis/recall")));
@@ -173,6 +175,7 @@ public class HMPPSDomainEventsTest {
                 assertThat(hmppsEventMessages).singleElement().satisfies(event -> {
                     assertThatJson(event).node("eventType").isEqualTo("prison-offender-events.prisoner.received");
                     assertThatJson(event).node("additionalInformation.reason").isEqualTo("RECALL");
+                    assertThatJson(event).node("additionalInformation.source").isEqualTo("PROBATION");
                 });
 
                 CommunityApiExtension.server.verify(getRequestedFor(WireMock.urlEqualTo("/secure/offenders/nomsNumber/A5194DY/convictions/active/nsis/recall")));

--- a/src/test/java/uk/gov/justice/hmpps/offenderevents/services/HMPPSDomainEventsEmitterTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/offenderevents/services/HMPPSDomainEventsEmitterTest.java
@@ -21,6 +21,8 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import uk.gov.justice.hmpps.offenderevents.model.OffenderEvent;
 import uk.gov.justice.hmpps.offenderevents.services.ReceivePrisonerReasonCalculator.Reason;
+import uk.gov.justice.hmpps.offenderevents.services.ReceivePrisonerReasonCalculator.RecallReason;
+import uk.gov.justice.hmpps.offenderevents.services.ReceivePrisonerReasonCalculator.Source;
 
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
@@ -83,7 +85,7 @@ class HMPPSDomainEventsEmitterTest {
     @DisplayName("Will send to topic for these events")
     @MockitoSettings(strictness = Strictness.LENIENT)
     void willSendToTopicForTheseEvents(String prisonEventType, String eventType) {
-        when(receivePrisonerReasonCalculator.calculateReasonForPrisoner(any())).thenReturn(Reason.UNKNOWN);
+        when(receivePrisonerReasonCalculator.calculateReasonForPrisoner(any())).thenReturn(new RecallReason(Reason.UNKNOWN, Source.PRISON));
 
         emitter.convertAndSendWhenSignificant(OffenderEvent
             .builder()
@@ -112,7 +114,7 @@ class HMPPSDomainEventsEmitterTest {
 
         @BeforeEach
         void setUp() {
-            when(receivePrisonerReasonCalculator.calculateReasonForPrisoner(any())).thenReturn(Reason.RECALL);
+            when(receivePrisonerReasonCalculator.calculateReasonForPrisoner(any())).thenReturn(new RecallReason(Reason.RECALL, Source.PRISON));
 
             emitter.convertAndSendWhenSignificant(OffenderEvent
                 .builder()

--- a/src/test/java/uk/gov/justice/hmpps/offenderevents/services/HMPPSDomainEventsEmitterTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/offenderevents/services/HMPPSDomainEventsEmitterTest.java
@@ -85,7 +85,7 @@ class HMPPSDomainEventsEmitterTest {
     @DisplayName("Will send to topic for these events")
     @MockitoSettings(strictness = Strictness.LENIENT)
     void willSendToTopicForTheseEvents(String prisonEventType, String eventType) {
-        when(receivePrisonerReasonCalculator.calculateReasonForPrisoner(any())).thenReturn(new RecallReason(Reason.UNKNOWN, Source.PRISON));
+        when(receivePrisonerReasonCalculator.calculateMostLikelyReasonForPrisoner(any())).thenReturn(new RecallReason(Reason.UNKNOWN, Source.PRISON));
 
         emitter.convertAndSendWhenSignificant(OffenderEvent
             .builder()
@@ -114,7 +114,7 @@ class HMPPSDomainEventsEmitterTest {
 
         @BeforeEach
         void setUp() {
-            when(receivePrisonerReasonCalculator.calculateReasonForPrisoner(any())).thenReturn(new RecallReason(Reason.RECALL, Source.PRISON));
+            when(receivePrisonerReasonCalculator.calculateMostLikelyReasonForPrisoner(any())).thenReturn(new RecallReason(Reason.RECALL, Source.PRISON));
 
             emitter.convertAndSendWhenSignificant(OffenderEvent
                 .builder()

--- a/src/test/java/uk/gov/justice/hmpps/offenderevents/services/ReceivePrisonerReasonCalculatorTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/offenderevents/services/ReceivePrisonerReasonCalculatorTest.java
@@ -57,7 +57,7 @@ class ReceivePrisonerReasonCalculatorTest {
     void reasonIsRecallIfBothLegalStatusRECALLAndCalculatedRecallTrue() {
         when(prisonApiService.getPrisonerDetails(any())).thenReturn(prisonerDetails("RECALL", true));
 
-        assertThat(calculator.calculateReasonForPrisoner("A1234GH").reason()).isEqualTo(Reason.RECALL);
+        assertThat(calculator.calculateMostLikelyReasonForPrisoner("A1234GH").reason()).isEqualTo(Reason.RECALL);
     }
 
     @Test
@@ -65,17 +65,17 @@ class ReceivePrisonerReasonCalculatorTest {
     void reasonIsRecallIfOnlyCalculatedRecallIsTrue() {
         when(prisonApiService.getPrisonerDetails(any())).thenReturn(prisonerDetails("UNKNOWN", true));
 
-        assertThat(calculator.calculateReasonForPrisoner("A1234GH").reason()).isEqualTo(Reason.RECALL);
+        assertThat(calculator.calculateMostLikelyReasonForPrisoner("A1234GH").reason()).isEqualTo(Reason.RECALL);
     }
 
     @Test
     @DisplayName("TAP movement type takes precedence over recall")
     void tAPMovementTypeTakesPrecedenceOverRecall() {
         when(prisonApiService.getPrisonerDetails(any())).thenReturn(prisonerDetails("RECALL", true, "ADM"));
-        assertThat(calculator.calculateReasonForPrisoner("A1234GH").reason()).isEqualTo(Reason.RECALL);
+        assertThat(calculator.calculateMostLikelyReasonForPrisoner("A1234GH").reason()).isEqualTo(Reason.RECALL);
 
         when(prisonApiService.getPrisonerDetails(any())).thenReturn(prisonerDetails("RECALL", true, "TAP"));
-        assertThat(calculator.calculateReasonForPrisoner("A1234GH").reason()).isEqualTo(Reason.TEMPORARY_ABSENCE_RETURN);
+        assertThat(calculator.calculateMostLikelyReasonForPrisoner("A1234GH").reason()).isEqualTo(Reason.TEMPORARY_ABSENCE_RETURN);
     }
 
     @Test
@@ -84,7 +84,7 @@ class ReceivePrisonerReasonCalculatorTest {
         when(communityApiService.getRecalls(any())).thenReturn(Optional.empty());
         when(prisonApiService.getPrisonerDetails(any())).thenReturn(prisonerDetails("UNKNOWN", false));
 
-        assertThat(calculator.calculateReasonForPrisoner("A1234GH").reason()).isEqualTo(Reason.UNKNOWN);
+        assertThat(calculator.calculateMostLikelyReasonForPrisoner("A1234GH").reason()).isEqualTo(Reason.UNKNOWN);
     }
 
     @Test
@@ -92,7 +92,7 @@ class ReceivePrisonerReasonCalculatorTest {
     void reasonIsREMANDWhenLegalStatusIsREMAND() {
         when(prisonApiService.getPrisonerDetails(any())).thenReturn(prisonerDetails("REMAND", false));
 
-        assertThat(calculator.calculateReasonForPrisoner("A1234GH").reason()).isEqualTo(Reason.REMAND);
+        assertThat(calculator.calculateMostLikelyReasonForPrisoner("A1234GH").reason()).isEqualTo(Reason.REMAND);
     }
 
     @ParameterizedTest
@@ -103,7 +103,7 @@ class ReceivePrisonerReasonCalculatorTest {
         when(communityApiService.getRecalls(any())).thenReturn(Optional.empty());
         when(prisonApiService.getPrisonerDetails(any())).thenReturn(prisonerDetails(legalStatus.name(), false));
 
-        assertThat(calculator.calculateReasonForPrisoner("A1234GH").reason()).isEqualTo(reason);
+        assertThat(calculator.calculateMostLikelyReasonForPrisoner("A1234GH").reason()).isEqualTo(reason);
     }
 
     private PrisonerDetails prisonerDetails(String legalStatus, boolean recall) {
@@ -144,7 +144,7 @@ class ReceivePrisonerReasonCalculatorTest {
             void legalStatusIsMappedToReason(LegalStatus legalStatus, Reason reason) {
                 when(prisonApiService.getPrisonerDetails(any())).thenReturn(prisonerDetails(legalStatus.name(), false));
 
-                assertThat(calculator.calculateReasonForPrisoner("A1234GH").reason()).isEqualTo(reason);
+                assertThat(calculator.calculateMostLikelyReasonForPrisoner("A1234GH").reason()).isEqualTo(reason);
             }
 
         }
@@ -177,7 +177,7 @@ class ReceivePrisonerReasonCalculatorTest {
             void legalStatusIsMappedToReason(LegalStatus legalStatus, Reason reason) {
                 when(prisonApiService.getPrisonerDetails(any())).thenReturn(prisonerDetails(legalStatus.name(), false));
 
-                assertThat(calculator.calculateReasonForPrisoner("A1234GH").reason()).isEqualTo(reason);
+                assertThat(calculator.calculateMostLikelyReasonForPrisoner("A1234GH").reason()).isEqualTo(reason);
             }
         }
 
@@ -210,7 +210,7 @@ class ReceivePrisonerReasonCalculatorTest {
             void legalStatusIsMappedToReason(LegalStatus legalStatus, Reason reason) {
                 when(prisonApiService.getPrisonerDetails(any())).thenReturn(prisonerDetails(legalStatus.name(), false));
 
-                assertThat(calculator.calculateReasonForPrisoner("A1234GH").reason()).isEqualTo(reason);
+                assertThat(calculator.calculateMostLikelyReasonForPrisoner("A1234GH").reason()).isEqualTo(reason);
             }
 
         }
@@ -244,17 +244,17 @@ class ReceivePrisonerReasonCalculatorTest {
             void legalStatusIsMappedToReason(LegalStatus legalStatus, Reason reason) {
                 when(prisonApiService.getPrisonerDetails(any())).thenReturn(prisonerDetails(legalStatus.name(), false));
 
-                assertThat(calculator.calculateReasonForPrisoner("A1234GH").reason()).isEqualTo(reason);
+                assertThat(calculator.calculateMostLikelyReasonForPrisoner("A1234GH").reason()).isEqualTo(reason);
             }
 
             @Test
             @DisplayName("reason source will be prison")
             void reasonSourceWillBeProbationWhenOverridden() {
                 when(prisonApiService.getPrisonerDetails(any())).thenReturn(prisonerDetails(LegalStatus.SENTENCED.name(), false));
-                assertThat(calculator.calculateReasonForPrisoner("A1234GH").source()).isEqualTo(Source.PRISON);
+                assertThat(calculator.calculateMostLikelyReasonForPrisoner("A1234GH").source()).isEqualTo(Source.PRISON);
 
                 when(prisonApiService.getPrisonerDetails(any())).thenReturn(prisonerDetails(LegalStatus.IMMIGRATION_DETAINEE.name(), false));
-                assertThat(calculator.calculateReasonForPrisoner("A1234GH").source()).isEqualTo(Source.PRISON);
+                assertThat(calculator.calculateMostLikelyReasonForPrisoner("A1234GH").source()).isEqualTo(Source.PRISON);
             }
 
         }
@@ -290,7 +290,7 @@ class ReceivePrisonerReasonCalculatorTest {
             void legalStatusIsMappedToReason(LegalStatus legalStatus, Reason reason) {
                 when(prisonApiService.getPrisonerDetails(any())).thenReturn(prisonerDetails(legalStatus.name(), false));
 
-                assertThat(calculator.calculateReasonForPrisoner("A1234GH").reason()).isEqualTo(reason);
+                assertThat(calculator.calculateMostLikelyReasonForPrisoner("A1234GH").reason()).isEqualTo(reason);
             }
 
         }
@@ -324,27 +324,27 @@ class ReceivePrisonerReasonCalculatorTest {
             void legalStatusIsMappedToReason(LegalStatus legalStatus, Reason reason) {
                 when(prisonApiService.getPrisonerDetails(any())).thenReturn(prisonerDetails(legalStatus.name(), false));
 
-                assertThat(calculator.calculateReasonForPrisoner("A1234GH").reason()).isEqualTo(reason);
+                assertThat(calculator.calculateMostLikelyReasonForPrisoner("A1234GH").reason()).isEqualTo(reason);
             }
 
             @Test
             @DisplayName("reason source will be probation when overridden")
             void reasonSourceWillBeProbationWhenOverridden() {
                 when(prisonApiService.getPrisonerDetails(any())).thenReturn(prisonerDetails(LegalStatus.SENTENCED.name(), false));
-                assertThat(calculator.calculateReasonForPrisoner("A1234GH").source()).isEqualTo(Source.PROBATION);
+                assertThat(calculator.calculateMostLikelyReasonForPrisoner("A1234GH").source()).isEqualTo(Source.PROBATION);
 
                 when(prisonApiService.getPrisonerDetails(any())).thenReturn(prisonerDetails(LegalStatus.IMMIGRATION_DETAINEE.name(), false));
-                assertThat(calculator.calculateReasonForPrisoner("A1234GH").source()).isEqualTo(Source.PRISON);
+                assertThat(calculator.calculateMostLikelyReasonForPrisoner("A1234GH").source()).isEqualTo(Source.PRISON);
             }
 
             @Test
             @DisplayName("will add a further information message when overridden")
             void willAddAFurtherInformationMessageWhenOverridden() {
                 when(prisonApiService.getPrisonerDetails(any())).thenReturn(prisonerDetails(LegalStatus.SENTENCED.name(), false));
-                assertThat(calculator.calculateReasonForPrisoner("A1234GH").details()).isEqualTo("Recall referral date 2021-06-13");
+                assertThat(calculator.calculateMostLikelyReasonForPrisoner("A1234GH").details()).isEqualTo("Recall referral date 2021-06-13");
 
                 when(prisonApiService.getPrisonerDetails(any())).thenReturn(prisonerDetails(LegalStatus.IMMIGRATION_DETAINEE.name(), false));
-                assertThat(calculator.calculateReasonForPrisoner("A1234GH").details()).isNull();
+                assertThat(calculator.calculateMostLikelyReasonForPrisoner("A1234GH").details()).isNull();
             }
         }
     }


### PR DESCRIPTION
This introduces additional information about the receive reason so that clients can understand why a receive event was calculated.

The 2 additional fields in the event:
* source - either PRISON or PROBATION
* details - free form text