### PR TITLE
PI-377 Publish case notes as domain events

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -11,6 +11,7 @@ generic-service:
     PRISON_API_BASE_URL: "https://api-dev.prison.service.justice.gov.uk"
     COMMUNITY_API_BASE_URL: "https://community-api.test.probation.service.justice.gov.uk"
     OAUTH_API_BASE_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
+    CASENOTES_API_BASE_URL: "https://dev.offender-case-notes.service.justice.gov.uk"
     WIND_BACK_SECONDS: "10"
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
     APPLICATION_LISTENER_TOTALDELAYDURATION: "PT1M"

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -9,6 +9,7 @@ generic-service:
     PRISON_API_BASE_URL: "https://api-preprod.prison.service.justice.gov.uk"
     COMMUNITY_API_BASE_URL: "https://community-api.pre-prod.delius.probation.hmpps.dsd.io"
     OAUTH_API_BASE_URL: "https://sign-in-preprod.hmpps.service.justice.gov.uk/auth"
+    CASENOTES_API_BASE_URL: "https://preprod.offender-case-notes.service.justice.gov.uk"
     WIND_BACK_SECONDS: "10"
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.json
     APPLICATION_LISTENER_TOTALDELAYDURATION: "PT45M"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -9,6 +9,7 @@ generic-service:
     PRISON_API_BASE_URL: "https://api.prison.service.justice.gov.uk"
     COMMUNITY_API_BASE_URL: "https://community-api.probation.service.justice.gov.uk"
     OAUTH_API_BASE_URL: "https://sign-in.hmpps.service.justice.gov.uk/auth"
+    CASENOTES_API_BASE_URL: "https://offender-case-notes.service.justice.gov.uk"
     WIND_BACK_SECONDS: "400"
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.json
     APPLICATION_LISTENER_TOTALDELAYDURATION: "PT45M"

--- a/src/main/java/uk/gov/justice/hmpps/offenderevents/config/OffenderEventsProperties.java
+++ b/src/main/java/uk/gov/justice/hmpps/offenderevents/config/OffenderEventsProperties.java
@@ -27,11 +27,18 @@ public class OffenderEventsProperties {
      */
     private final String oauthApiBaseUrl;
 
+    /**
+     * Case Notes API Rest URL endpoint ("http://localhost:8083")
+     */
+    private final String casenotesApiBaseUrl;
+
     public OffenderEventsProperties(@Value("${prison.api.base.url}") @URL final String prisonApiBaseUrl,
                                     @Value("${community.api.base.url}") @URL final String communityApiBaseUrl,
-                                    @Value("${oauth.api.base.url}") @URL final String oauthApiBaseUrl) {
+                                    @Value("${oauth.api.base.url}") @URL final String oauthApiBaseUrl,
+                                    @Value("${casenotes.api.base.url}") @URL final String casenotesApiBaseUrl) {
         this.prisonApiBaseUrl = prisonApiBaseUrl;
         this.communityApiBaseUrl = communityApiBaseUrl;
         this.oauthApiBaseUrl = oauthApiBaseUrl;
+        this.casenotesApiBaseUrl = casenotesApiBaseUrl;
     }
 }

--- a/src/main/java/uk/gov/justice/hmpps/offenderevents/model/HmppsDomainEvent.java
+++ b/src/main/java/uk/gov/justice/hmpps/offenderevents/model/HmppsDomainEvent.java
@@ -1,0 +1,71 @@
+package uk.gov.justice.hmpps.offenderevents.model;
+
+import com.amazonaws.services.sns.model.MessageAttributeValue;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder(toBuilder = true)
+public class HmppsDomainEvent {
+    @Builder.Default
+    private int version = 1;
+    private String eventType;
+    private String description;
+    private String detailUrl;
+    private String occurredAt;
+    private String publishedAt;
+    private PersonReference personReference;
+    @Builder.Default
+    private Map<String, String> additionalInformation = new HashMap<>();
+
+    public HmppsDomainEvent withAdditionalInformation(String key, String value) {
+        if (value != null) {
+            additionalInformation.put(key, value);
+        }
+        return this;
+    }
+
+    public Map<String, String> asTelemetryMap() {
+        final var elements = new HashMap<>(Map.of(
+            "eventType", eventType,
+            "occurredAt", occurredAt,
+            "nomsNumber", personReference.nomsNumber()
+        ));
+        elements.putAll(additionalInformation);
+        return elements;
+    }
+
+    public Map<String, MessageAttributeValue> asMetadataMap() {
+        final var attributes = new HashMap<>(Map.of(
+            "eventType", new MessageAttributeValue().withDataType("String").withStringValue(eventType)
+        ));
+        if (additionalInformation.containsKey("caseNoteType")) attributes.put(
+            "caseNoteType", new MessageAttributeValue().withDataType("String").withStringValue(additionalInformation.get("caseNoteType"))
+        );
+        return attributes;
+    }
+
+    public record PersonIdentifier(String type, String value) {}
+
+    public record PersonReference(List<PersonIdentifier> identifiers) {
+        public PersonReference(String nomsNumber) {
+            this(List.of(new PersonIdentifier("NOMS", nomsNumber)));
+        }
+
+        public String nomsNumber() {
+            return identifiers.stream()
+                .filter(identifier -> "NOMS".equals(identifier.type())).findFirst()
+                .map(PersonIdentifier::value).orElseThrow();
+        }
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -5,6 +5,8 @@ prison:
   api.base.url: ${PRISON_API_BASE_URL:http://localhost:8081}
 community:
   api.base.url: ${COMMUNITY_API_BASE_URL:http://localhost:8082}
+casenotes:
+  api.base.url: ${CASENOTES_API_BASE_URL:http://localhost:8083}
 
 offender.events:
   client:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -9,6 +9,7 @@ management.endpoint:
 oauth.api.base.url: http://localhost:8090/auth
 prison.api.base.url: http://localhost:8086
 community.api.base.url: http://localhost:8087
+casenotes.api.base.url: http://localhost:8088
 
 offender.events:
   client:


### PR DESCRIPTION
This change is to publish case notes to the domain events topic, instead of offender events.  It uses a similar mechanism as released/received/merged, however it doesn't rely on the event being first published to the offender events topic.

I've also updated HmppsDomainEvent to be a normal class instead of a record, with additionalInformation as a Map.  This was to reduce the amount of nulls being passed around, which was starting to get unwieldy due to the increasing number of different formats for the AdditionalInformation record.  Happy to revert this bit back though if the old method is preferred.