### PR TITLE
SDIT-1806 Changed contact update to more meaningful name

### DIFF
--- a/src/main/kotlin/uk/gov/justice/hmpps/offenderevents/model/HmppsDomainEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/offenderevents/model/HmppsDomainEvent.kt
@@ -26,6 +26,10 @@ data class HmppsDomainEvent(
     if (value != null) additionalInformation[key] = value.toString()
     return this
   }
+  fun withAdditionalInformation(key: String, value: Boolean?): HmppsDomainEvent {
+    additionalInformation[key] = (value ?: false).toString()
+    return this
+  }
 
   fun withAdditionalInformation(key: String, value: LocalDate?): HmppsDomainEvent {
     if (value != null) additionalInformation[key] = value.format(DateTimeFormatter.ISO_DATE)


### PR DESCRIPTION
The update contacts are only fired when the approved visitor flag is updated hence the name change

Also small refactor to remove code duplication and improve readability