### PR TITLE
SDIT-1910 New domain events for person-restriction changes

### DIFF
--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   localstack:
     image: localstack/localstack:3

--- a/src/main/kotlin/uk/gov/justice/hmpps/offenderevents/model/OffenderEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/offenderevents/model/OffenderEvent.kt
@@ -28,8 +28,8 @@ abstract class OffenderEvent(
       "NON_ASSOCIATION_DETAIL-DELETED" to NonAssociationDetailsOffenderEvent::class.java,
       "RESTRICTION-UPSERTED" to RestrictionOffenderEvent::class.java,
       "RESTRICTION-DELETED" to RestrictionOffenderEvent::class.java,
-      "PERSON_RESTRICTION-UPSERTED" to PersonRestrictionOffenderEvent::class.java,
-      "PERSON_RESTRICTION-DELETED" to PersonRestrictionOffenderEvent::class.java,
+      "PERSON_RESTRICTION-UPSERTED" to PersonRestrictionOffenderEventUpserted::class.java,
+      "PERSON_RESTRICTION-DELETED" to PersonRestrictionOffenderEventDeleted::class.java,
       "VISITOR_RESTRICTION-UPSERTED" to VisitorRestrictionOffenderEvent::class.java,
       "VISITOR_RESTRICTION-DELETED" to VisitorRestrictionOffenderEvent::class.java,
       "PRISONER_ACTIVITY-UPDATE" to PrisonerActivityUpdateEvent::class.java,
@@ -119,7 +119,7 @@ class RestrictionOffenderEvent(
   offenderIdDisplay = offenderIdDisplay,
 )
 
-class PersonRestrictionOffenderEvent(
+abstract class PersonRestrictionOffenderEvent(
   eventDatetime: LocalDateTime,
   offenderIdDisplay: String? = null,
 
@@ -134,6 +134,54 @@ class PersonRestrictionOffenderEvent(
 ) : OffenderEvent(
   eventDatetime = eventDatetime,
   offenderIdDisplay = offenderIdDisplay,
+)
+
+class PersonRestrictionOffenderEventUpserted(
+  eventDatetime: LocalDateTime,
+  offenderIdDisplay: String? = null,
+  contactPersonId: Long?,
+  offenderPersonRestrictionId: Long?,
+  restrictionType: String?,
+  effectiveDate: LocalDate?,
+  expiryDate: LocalDate?,
+  authorisedById: Long?,
+  comment: String?,
+  enteredById: Long?,
+) : PersonRestrictionOffenderEvent(
+  eventDatetime,
+  offenderIdDisplay,
+  contactPersonId,
+  offenderPersonRestrictionId,
+  restrictionType,
+  effectiveDate,
+  expiryDate,
+  authorisedById,
+  comment,
+  enteredById,
+)
+
+class PersonRestrictionOffenderEventDeleted(
+  eventDatetime: LocalDateTime,
+  offenderIdDisplay: String? = null,
+  contactPersonId: Long?,
+  offenderPersonRestrictionId: Long?,
+  restrictionType: String?,
+  effectiveDate: LocalDate?,
+  expiryDate: LocalDate?,
+  authorisedById: Long?,
+  comment: String?,
+  enteredById: Long?,
+) : PersonRestrictionOffenderEvent(
+  eventDatetime,
+  offenderIdDisplay,
+  contactPersonId,
+  offenderPersonRestrictionId,
+  restrictionType,
+  effectiveDate,
+  expiryDate,
+  authorisedById,
+  comment,
+  enteredById,
 )
 
 class VisitorRestrictionOffenderEvent(

--- a/src/main/resources/swagger-description.html
+++ b/src/main/resources/swagger-description.html
@@ -84,8 +84,8 @@ conservative <b>offender.events</b>.
 <h4>Event details</h4>
 <div>
     <ul>
-      <li>
-        <b>prison-offender-events.prisoner.released</b> is raised when a prisoner is released from prison, this includes temporary releases
+      <li class="pt2">
+        <b class="f4">prison-offender-events.prisoner.released</b> is raised when a prisoner is released from prison, this includes temporary releases
         such as court appearances and transfers. We would recommend consumers to ensure their service is idempotent, there are scenarios where multiple events maybe raised for same release.
         <h3>Additional Information</h3>
             <ul>
@@ -117,8 +117,8 @@ conservative <b>offender.events</b>.
               <li><b>nomisMovementReasonCode</b> string - the reason code for the last movement. Since this is the literal NOMIS reference data that can change clients should be cautious of tightly integrating with this value. MOVE_RSN is the reference data domain in NOMIS</li>
             </ul>
       </li>
-      <li>
-        <b>prison-offender-events.prisoner.received</b> is raised when a prisoner is received to prison, this may be due to remand, a conviction or a recall from a broken licence. Also included are returns from temporary absences and transfers.
+      <li class="pt4">
+        <b class="f4">prison-offender-events.prisoner.received</b> is raised when a prisoner is received to prison, this may be due to remand, a conviction or a recall from a broken licence. Also included are returns from temporary absences and transfers.
         We would recommend consumers to ensure their service is idempotent, there are scenarios where multiple events maybe raised for same receive.
         <h3>Additional Information</h3>
             <ul>
@@ -149,8 +149,8 @@ conservative <b>offender.events</b>.
               <li><b>nomisMovementReasonCode</b> string - the reason code for the last movement. Since this is the literal NOMIS reference data that can change clients should be cautious of tightly integrating with this value. MOVE_RSN is the reference data domain in NOMIS</li>
             </ul>
       </li>
-      <li>
-        <b>prison-offender-events.prisoner.merged</b> is raised when a prisoner is merged into an exists prisoner record. This will mean that the prisoner will be
+      <li class="pt4">
+        <b class="f4">prison-offender-events.prisoner.merged</b> is raised when a prisoner is merged into an exists prisoner record. This will mean that the prisoner will be
         now attached to the original NOMS (prisoner) number and the new one removed from NOMIS
         <h3>Additional Information</h3>
             <ul>
@@ -163,8 +163,8 @@ conservative <b>offender.events</b>.
               <li><b>removedNomsNumber</b> string - NOMS number that was MERGED into <em>nomsNumber</em> and then removed</li>
             </ul>
       </li>
-      <li>
-        <b>prison-offender-events.prisoner.non-association-detail.changed</b> is raised when a prisoner non-association is created/updated/deleted.
+      <li class="pt4">
+        <b class="f4">prison-offender-events.prisoner.non-association-detail.changed</b> is raised when a prisoner non-association is created/updated/deleted.
         These events occur in pairs because the non-association is created both ways round.
         <h3>Additional Information</h3>
         <ul>
@@ -194,8 +194,9 @@ conservative <b>offender.events</b>.
           <li><b>comment</b> string - optional comment</li>
         </ul>
       </li>
-      <li>
-        <b>prison-offender-events.prisoner.restriction.changed</b> is raised when a prisoner visits restriction is created/updated/deleted.
+      <li class="pt4">
+        <b class="f4">prison-offender-events.prisoner.restriction.changed</b> is raised when a prisoner visits restriction is created/updated/deleted.
+        <p>NOTE: Deprecated: please use prison-offender-events.prisoner.restriction.upserted or prison-offender-events.prisoner.restriction.deleted</p>
         <h3>Additional Information</h3>
         <ul>
           <li><b>nomsNumber</b> string - NOMS number of the prisoner</li>
@@ -221,8 +222,62 @@ conservative <b>offender.events</b>.
           <li><b>enteredById</b> string - NOMIS staff id of creator</li>
         </ul>
       </li>
-      <li>
-        <b>prison-offender-events.prisoner.person-restriction.changed</b> is raised when a prisoner visitor restriction is created/updated/deleted.
+      <li class="pt4">
+        <b class="f4">prison-offender-events.prisoner.restriction.upserted</b> is raised when a prisoner visits restriction is created or updated.
+        <h3>Additional Information</h3>
+        <ul>
+          <li><b>nomsNumber</b> string - NOMS number of the prisoner</li>
+          <li><b>bookingId</b> string - NOMIS booking id of the prisoner</li>
+          <li><b>offenderRestrictionId</b> string - NOMIS id of the restriction record</li>
+          <li><b>restrictionType</b> enum (from domain 'VST_RST_TYPE') -
+            <ul>
+              <li><b>ACC</b> access requirements</li>
+              <li><b>BAN</b> banned</li>
+              <li><b>CCTV</b> CCTV</li>
+              <li><b>CHILD</b> child visitors to be vetted</li>
+              <li><b>CLOSED</b> closed</li>
+              <li><b>DIHCON</b> disability health concerns</li>
+              <li><b>NONCON</b> non-contact visit</li>
+              <li><b>PREINF</b> previous info</li>
+              <li><b>RESTRICT</b> restricted</li>
+            </ul>
+          </li>
+          <li><b>effectiveDate</b> string - start date of restriction</li>
+          <li><b>expiryDate</b> string - optional end date</li>
+          <li><b>comment</b> string - optional comment</li>
+          <li><b>authorisedById</b> string - NOMIS staff id of authoriser</li>
+          <li><b>enteredById</b> string - NOMIS staff id of creator</li>
+        </ul>
+      </li>
+      <li class="pt4">
+        <b class="f4">prison-offender-events.prisoner.restriction.deleted</b> is raised when a prisoner visits restriction is deleted.
+        <h3>Additional Information</h3>
+        <ul>
+          <li><b>nomsNumber</b> string - NOMS number of the prisoner</li>
+          <li><b>bookingId</b> string - NOMIS booking id of the prisoner</li>
+          <li><b>offenderRestrictionId</b> string - NOMIS id of the restriction record</li>
+          <li><b>restrictionType</b> enum (from domain 'VST_RST_TYPE') -
+            <ul>
+              <li><b>ACC</b> access requirements</li>
+              <li><b>BAN</b> banned</li>
+              <li><b>CCTV</b> CCTV</li>
+              <li><b>CHILD</b> child visitors to be vetted</li>
+              <li><b>CLOSED</b> closed</li>
+              <li><b>DIHCON</b> disability health concerns</li>
+              <li><b>NONCON</b> non-contact visit</li>
+              <li><b>PREINF</b> previous info</li>
+              <li><b>RESTRICT</b> restricted</li>
+            </ul>
+          </li>
+          <li><b>effectiveDate</b> string - start date of restriction</li>
+          <li><b>expiryDate</b> string - optional end date</li>
+          <li><b>comment</b> string - optional comment</li>
+          <li><b>authorisedById</b> string - NOMIS staff id of authoriser</li>
+          <li><b>enteredById</b> string - NOMIS staff id of creator</li>
+        </ul>
+      </li>
+      <li class="pt4">
+        <b class="f4">prison-offender-events.prisoner.person-restriction.changed</b> is raised when a prisoner visitor restriction is created/updated/deleted.
         <h3>Additional Information</h3>
         <ul>
           <li><b>nomsNumber</b> string - NOMS number of the prisoner</li>
@@ -248,8 +303,8 @@ conservative <b>offender.events</b>.
           <li><b>enteredById</b> string - NOMIS staff id of creator</li>
         </ul>
       </li>
-      <li>
-        <b>prison-offender-events.visitor.restriction.changed</b> is raised when a global visitor restriction is created/updated/deleted.
+      <li class="pt4">
+        <b class="f4">prison-offender-events.visitor.restriction.changed</b> is raised when a global visitor restriction is created/updated/deleted.
         <h3>Additional Information</h3>
         <ul>
           <li><b>contactPersonId</b> string - NOMIS person id of the visitor</li>
@@ -273,8 +328,8 @@ conservative <b>offender.events</b>.
           <li><b>enteredById</b> string - NOMIS staff id of creator</li>
         </ul>
       </li>
-      <li>
-        <b>prison-offender-events.prisoner.contact-added</b> is raised when a person is added as priosner contact
+      <li class="pt4">
+        <b class="f4">prison-offender-events.prisoner.contact-added</b> is raised when a person is added as priosner contact
         <h3>Additional Information</h3>
         <ul>
           <li><b>nomsNumber</b> string - Prisoner number of the prisoner that has the contact</li>
@@ -285,8 +340,8 @@ conservative <b>offender.events</b>.
           <li><b>username</b> string - NOMIS user that made the change</li>
         </ul>
       </li>
-      <li>
-        <b>prison-offender-events.prisoner.contact-removed</b> is raised when a person has been removed as contact to a prisoner. Only the relationship is removed not the actual person
+      <li class="pt4">
+        <b class="f4">prison-offender-events.prisoner.contact-removed</b> is raised when a person has been removed as contact to a prisoner. Only the relationship is removed not the actual person
         <h3>Additional Information</h3>
         <ul>
           <li><b>nomsNumber</b> string - Prisoner number of the prisoner that has the contact</li>
@@ -296,8 +351,8 @@ conservative <b>offender.events</b>.
           <li><b>approvedVisitor</b> boolean - flag to indicate if the contact was an approved visitor at the point the event was triggered</li>
         </ul>
       </li>
-      <li>
-        <b>prison-offender-events.prisoner.contact-approved</b> is raised when a contact has been approved as visitor to the prisoner
+      <li class="pt4">
+        <b class="f4">prison-offender-events.prisoner.contact-approved</b> is raised when a contact has been approved as visitor to the prisoner
         <h3>Additional Information</h3>
         <ul>
           <li><b>nomsNumber</b> string - Prisoner number of the prisoner that has the contact</li>
@@ -308,8 +363,8 @@ conservative <b>offender.events</b>.
           <li><b>username</b> string - NOMIS user that made the change</li>
         </ul>
       </li>
-      <li>
-        <b>prison-offender-events.prisoner.contact-unapproved</b> is raised when a contact has had their approval to visit the prisoner revoked
+      <li class="pt4">
+        <b class="f4">prison-offender-events.prisoner.contact-unapproved</b> is raised when a contact has had their approval to visit the prisoner revoked
         <h3>Additional Information</h3>
         <ul>
           <li><b>nomsNumber</b> string - Prisoner number of the prisoner that has the contact</li>

--- a/src/main/resources/swagger-description.html
+++ b/src/main/resources/swagger-description.html
@@ -196,12 +196,38 @@ conservative <b>offender.events</b>.
       </li>
       <li class="pt4">
         <b class="f4">prison-offender-events.prisoner.restriction.changed</b> is raised when a prisoner visits restriction is created/updated/deleted.
+        <h3>Additional Information</h3>
+        <ul>
+          <li><b>nomsNumber</b> string - NOMS number of the prisoner</li>
+          <li><b>bookingId</b> string - NOMIS booking id of the prisoner</li>
+          <li><b>offenderRestrictionId</b> string - NOMIS id of the restriction record</li>
+          <li><b>restrictionType</b> enum (from domain 'VST_RST_TYPE') -
+            <ul>
+              <li><b>ACC</b> access requirements</li>
+              <li><b>BAN</b> banned</li>
+              <li><b>CCTV</b> CCTV</li>
+              <li><b>CHILD</b> child visitors to be vetted</li>
+              <li><b>CLOSED</b> closed</li>
+              <li><b>DIHCON</b> disability health concerns</li>
+              <li><b>NONCON</b> non-contact visit</li>
+              <li><b>PREINF</b> previous info</li>
+              <li><b>RESTRICT</b> restricted</li>
+            </ul>
+          </li>
+          <li><b>effectiveDate</b> string - start date of restriction</li>
+          <li><b>expiryDate</b> string - optional end date</li>
+          <li><b>comment</b> string - optional comment</li>
+          <li><b>authorisedById</b> string - NOMIS staff id of authoriser</li>
+          <li><b>enteredById</b> string - NOMIS staff id of creator</li>
+        </ul>
+      </li>
+      <li class="pt4">
+        <b class="f4">prison-offender-events.prisoner.person-restriction.changed</b> is raised when a global visitor restriction is created/updated/deleted.
         <p>NOTE: Deprecated: please use prison-offender-events.prisoner.restriction.upserted or prison-offender-events.prisoner.restriction.deleted</p>
         <h3>Additional Information</h3>
         <ul>
-          <li><b>nomsNumber</b> string - NOMS number of the prisoner</li>
-          <li><b>bookingId</b> string - NOMIS booking id of the prisoner</li>
-          <li><b>offenderRestrictionId</b> string - NOMIS id of the restriction record</li>
+          <li><b>contactPersonId</b> string - NOMIS person id of the visitor</li>
+          <li><b>offenderPersonRestrictionId</b> string - NOMIS id of the restriction record</li>
           <li><b>restrictionType</b> enum (from domain 'VST_RST_TYPE') -
             <ul>
               <li><b>ACC</b> access requirements</li>
@@ -223,12 +249,11 @@ conservative <b>offender.events</b>.
         </ul>
       </li>
       <li class="pt4">
-        <b class="f4">prison-offender-events.prisoner.restriction.upserted</b> is raised when a prisoner visits restriction is created or updated.
+        <b class="f4">prison-offender-events.prisoner.person-restriction.upserted</b> is raised when a global visitor restriction is created or updated.
         <h3>Additional Information</h3>
         <ul>
-          <li><b>nomsNumber</b> string - NOMS number of the prisoner</li>
-          <li><b>bookingId</b> string - NOMIS booking id of the prisoner</li>
-          <li><b>offenderRestrictionId</b> string - NOMIS id of the restriction record</li>
+          <li><b>contactPersonId</b> string - NOMIS person id of the visitor</li>
+          <li><b>offenderPersonRestrictionId</b> string - NOMIS id of the restriction record</li>
           <li><b>restrictionType</b> enum (from domain 'VST_RST_TYPE') -
             <ul>
               <li><b>ACC</b> access requirements</li>
@@ -250,37 +275,9 @@ conservative <b>offender.events</b>.
         </ul>
       </li>
       <li class="pt4">
-        <b class="f4">prison-offender-events.prisoner.restriction.deleted</b> is raised when a prisoner visits restriction is deleted.
+        <b class="f4">prison-offender-events.prisoner.person-restriction.changed</b> is raised when a global visitor restriction is deleted.
         <h3>Additional Information</h3>
         <ul>
-          <li><b>nomsNumber</b> string - NOMS number of the prisoner</li>
-          <li><b>bookingId</b> string - NOMIS booking id of the prisoner</li>
-          <li><b>offenderRestrictionId</b> string - NOMIS id of the restriction record</li>
-          <li><b>restrictionType</b> enum (from domain 'VST_RST_TYPE') -
-            <ul>
-              <li><b>ACC</b> access requirements</li>
-              <li><b>BAN</b> banned</li>
-              <li><b>CCTV</b> CCTV</li>
-              <li><b>CHILD</b> child visitors to be vetted</li>
-              <li><b>CLOSED</b> closed</li>
-              <li><b>DIHCON</b> disability health concerns</li>
-              <li><b>NONCON</b> non-contact visit</li>
-              <li><b>PREINF</b> previous info</li>
-              <li><b>RESTRICT</b> restricted</li>
-            </ul>
-          </li>
-          <li><b>effectiveDate</b> string - start date of restriction</li>
-          <li><b>expiryDate</b> string - optional end date</li>
-          <li><b>comment</b> string - optional comment</li>
-          <li><b>authorisedById</b> string - NOMIS staff id of authoriser</li>
-          <li><b>enteredById</b> string - NOMIS staff id of creator</li>
-        </ul>
-      </li>
-      <li class="pt4">
-        <b class="f4">prison-offender-events.prisoner.person-restriction.changed</b> is raised when a prisoner visitor restriction is created/updated/deleted.
-        <h3>Additional Information</h3>
-        <ul>
-          <li><b>nomsNumber</b> string - NOMS number of the prisoner</li>
           <li><b>contactPersonId</b> string - NOMIS person id of the visitor</li>
           <li><b>offenderPersonRestrictionId</b> string - NOMIS id of the restriction record</li>
           <li><b>restrictionType</b> enum (from domain 'VST_RST_TYPE') -

--- a/src/test/kotlin/uk/gov/justice/hmpps/offenderevents/services/HMPPSDomainEventsEmitterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/hmpps/offenderevents/services/HMPPSDomainEventsEmitterTest.kt
@@ -1263,7 +1263,6 @@ internal class HMPPSDomainEventsEmitterTest(@Autowired private val objectMapper:
         verify(hmppsEventSnsClient, times(2)).publish(capture())
         payload1 = firstValue.message()
         payload2 = secondValue.message()
-
       }
       argumentCaptor<Map<String, String>>().apply {
         verify(telemetryClient, times(2)).trackEvent(any(), capture(), isNull())
@@ -1330,7 +1329,7 @@ internal class HMPPSDomainEventsEmitterTest(@Autowired private val objectMapper:
     fun `will add correct fields to telemetry event`() {
       assertThat(telemetryAttributes1).containsEntry(
         "eventType",
-        "prison-offender-events.prisoner.person-restriction.upserted"
+        "prison-offender-events.prisoner.person-restriction.upserted",
       )
       assertThat(telemetryAttributes1).containsEntry("nomsNumber", "A1234GH")
       assertThat(telemetryAttributes1).containsEntry("occurredAt", "2022-12-04T10:00:00Z")
@@ -1338,7 +1337,7 @@ internal class HMPPSDomainEventsEmitterTest(@Autowired private val objectMapper:
       assertThat(telemetryAttributes1).containsEntry("comment", "a test")
       assertThat(telemetryAttributes2).containsEntry(
         "eventType",
-        "prison-offender-events.prisoner.person-restriction.changed"
+        "prison-offender-events.prisoner.person-restriction.changed",
       )
       assertThat(telemetryAttributes2).containsEntry("nomsNumber", "A1234GH")
       assertThat(telemetryAttributes2).containsEntry("occurredAt", "2022-12-04T10:00:00Z")
@@ -1395,7 +1394,6 @@ internal class HMPPSDomainEventsEmitterTest(@Autowired private val objectMapper:
         verify(hmppsEventSnsClient, times(2)).publish(capture())
         payload1 = firstValue.message()
         payload2 = secondValue.message()
-
       }
       argumentCaptor<Map<String, String>>().apply {
         verify(telemetryClient, times(2)).trackEvent(any(), capture(), isNull())
@@ -1484,7 +1482,7 @@ internal class HMPPSDomainEventsEmitterTest(@Autowired private val objectMapper:
         "authorisedById",
         "enteredById",
         "comment",
-        )
+      )
       assertThat(telemetryAttributes1).containsOnlyKeys(keys)
       assertThat(telemetryAttributes2).containsOnlyKeys(keys)
     }


### PR DESCRIPTION
This replaces the `prison-offender-events.prisoner.restriction.changed` event with more specific `prison-offender-events.prisoner.restriction.upserted` and `prison-offender-events.prisoner.restriction.deleted` events.