### PR TITLE
SDIT-2001 Split prison-offender-events.visitor.restriction.change

### DIFF
--- a/src/main/kotlin/uk/gov/justice/hmpps/offenderevents/model/OffenderEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/offenderevents/model/OffenderEvent.kt
@@ -30,8 +30,8 @@ abstract class OffenderEvent(
       "RESTRICTION-DELETED" to RestrictionOffenderEvent::class.java,
       "PERSON_RESTRICTION-UPSERTED" to PersonRestrictionOffenderEventUpserted::class.java,
       "PERSON_RESTRICTION-DELETED" to PersonRestrictionOffenderEventDeleted::class.java,
-      "VISITOR_RESTRICTION-UPSERTED" to VisitorRestrictionOffenderEvent::class.java,
-      "VISITOR_RESTRICTION-DELETED" to VisitorRestrictionOffenderEvent::class.java,
+      "VISITOR_RESTRICTION-UPSERTED" to VisitorRestrictionOffenderEventUpserted::class.java,
+      "VISITOR_RESTRICTION-DELETED" to VisitorRestrictionOffenderEventDeleted::class.java,
       "PRISONER_ACTIVITY-UPDATE" to PrisonerActivityUpdateEvent::class.java,
       "PRISONER_APPOINTMENT-UPDATE" to PrisonerAppointmentUpdateEvent::class.java,
       "IMPRISONMENT_STATUS-CHANGED" to ImprisonmentStatusChangedEvent::class.java,
@@ -185,10 +185,52 @@ class PersonRestrictionOffenderEventDeleted(
   enteredById = enteredById,
 )
 
-class VisitorRestrictionOffenderEvent(
+@JsonInclude(JsonInclude.Include.NON_NULL)
+class VisitorRestrictionOffenderEventUpserted(
   eventDatetime: LocalDateTime,
   offenderIdDisplay: String? = null,
+  personId: Long?,
+  restrictionType: String?,
+  effectiveDate: LocalDate?,
+  expiryDate: LocalDate?,
+  visitorRestrictionId: Long?,
+  enteredById: Long?,
+) : VisitorRestrictionOffenderEvent(
+  personId = personId,
+  restrictionType = restrictionType,
+  effectiveDate = effectiveDate,
+  expiryDate = expiryDate,
+  visitorRestrictionId = visitorRestrictionId,
+  enteredById = enteredById,
+  eventDatetime = eventDatetime,
+  offenderIdDisplay = offenderIdDisplay,
+)
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
+class VisitorRestrictionOffenderEventDeleted(
+  eventDatetime: LocalDateTime,
+  offenderIdDisplay: String? = null,
+  personId: Long?,
+  restrictionType: String?,
+  effectiveDate: LocalDate?,
+  expiryDate: LocalDate?,
+  visitorRestrictionId: Long?,
+  enteredById: Long?,
+) : VisitorRestrictionOffenderEvent(
+  personId = personId,
+  restrictionType = restrictionType,
+  effectiveDate = effectiveDate,
+  expiryDate = expiryDate,
+  visitorRestrictionId = visitorRestrictionId,
+  enteredById = enteredById,
+  eventDatetime = eventDatetime,
+  offenderIdDisplay = offenderIdDisplay,
+)
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+abstract class VisitorRestrictionOffenderEvent(
+  eventDatetime: LocalDateTime,
+  offenderIdDisplay: String? = null,
   val personId: Long?,
   val restrictionType: String?,
   val effectiveDate: LocalDate?,

--- a/src/main/resources/swagger-description.html
+++ b/src/main/resources/swagger-description.html
@@ -229,8 +229,9 @@ conservative <b>offender.events</b>.
         <p>NOTE: Deprecated: please use prison-offender-events.prisoner.restriction.upserted or prison-offender-events.prisoner.restriction.deleted</p>
         <h3>Additional Information</h3>
         <ul>
-          <li><b>contactPersonId</b> string - NOMIS person id of the visitor</li>
+          <li><b>contactPersonId</b> string - NOMIS contact id of the visitor</li>
           <li><b>offenderPersonRestrictionId</b> string - NOMIS id of the restriction record</li>
+          <li><b>personId</b> string - NOMIS person id of the restriction record</li>
           <li><b>restrictionType</b> enum (from domain 'VST_RST_TYPE') -
             <ul>
               <li><b>ACC</b> access requirements</li>
@@ -255,8 +256,9 @@ conservative <b>offender.events</b>.
         <b>prison-offender-events.prisoner.person-restriction.upserted</b> is raised when a global visitor restriction is created or updated.
         <h3>Additional Information</h3>
         <ul>
-          <li><b>contactPersonId</b> string - NOMIS person id of the visitor</li>
+          <li><b>contactPersonId</b> string - NOMIS contact id of the visitor</li>
           <li><b>offenderPersonRestrictionId</b> string - NOMIS id of the restriction record</li>
+          <li><b>personId</b> string - NOMIS person id of the restriction record</li>
           <li><b>restrictionType</b> enum (from domain 'VST_RST_TYPE') -
             <ul>
               <li><b>ACC</b> access requirements</li>
@@ -281,8 +283,9 @@ conservative <b>offender.events</b>.
         <b>prison-offender-events.prisoner.person-restriction.deleted</b> is raised when a global visitor restriction is deleted.
         <h3>Additional Information</h3>
         <ul>
-          <li><b>contactPersonId</b> string - NOMIS person id of the visitor</li>
+          <li><b>contactPersonId</b> string - NOMIS contact id of the visitor</li>
           <li><b>offenderPersonRestrictionId</b> string - NOMIS id of the restriction record</li>
+          <li><b>personId</b> string - NOMIS person id of the restriction record</li>
           <li><b>restrictionType</b> enum (from domain 'VST_RST_TYPE') -
             <ul>
               <li><b>ACC</b> access requirements</li>
@@ -304,10 +307,10 @@ conservative <b>offender.events</b>.
         </ul>
       </li>
       <li>
-        <b>prison-offender-events.visitor.restriction.changed</b> is raised when a global visitor restriction is created/updated/deleted.
+        <b>prison-offender-events.visitor.restriction.upserted</b> is raised when a global visitor restriction is created or updated
         <h3>Additional Information</h3>
         <ul>
-          <li><b>contactPersonId</b> string - NOMIS person id of the visitor</li>
+          <li><b>personId</b> string - NOMIS person id of the visitor</li>
           <li><b>visitorRestrictionId</b> string - NOMIS id of the restriction record</li>
           <li><b>restrictionType</b> enum (from domain 'VST_RST_TYPE') -
             <ul>
@@ -324,7 +327,30 @@ conservative <b>offender.events</b>.
           </li>
           <li><b>effectiveDate</b> string - start date of restriction</li>
           <li><b>expiryDate</b> string - optional end date</li>
-          <li><b>comment</b> string - optional comment</li>
+          <li><b>enteredById</b> string - NOMIS staff id of creator</li>
+        </ul>
+      </li>
+      <li>
+        <b>prison-offender-events.visitor.restriction.deleted</b> is raised when a global visitor restriction is deleted
+        <h3>Additional Information</h3>
+        <ul>
+          <li><b>personId</b> string - NOMIS person id of the visitor</li>
+          <li><b>visitorRestrictionId</b> string - NOMIS id of the restriction record</li>
+          <li><b>restrictionType</b> enum (from domain 'VST_RST_TYPE') -
+            <ul>
+              <li><b>ACC</b> access requirements</li>
+              <li><b>BAN</b> banned</li>
+              <li><b>CCTV</b> CCTV</li>
+              <li><b>CHILD</b> child visitors to be vetted</li>
+              <li><b>CLOSED</b> closed</li>
+              <li><b>DIHCON</b> disability health concerns</li>
+              <li><b>NONCON</b> non-contact visit</li>
+              <li><b>PREINF</b> previous info</li>
+              <li><b>RESTRICT</b> restricted</li>
+            </ul>
+          </li>
+          <li><b>effectiveDate</b> string - start date of restriction</li>
+          <li><b>expiryDate</b> string - optional end date</li>
           <li><b>enteredById</b> string - NOMIS staff id of creator</li>
         </ul>
       </li>

--- a/src/test/kotlin/uk/gov/justice/hmpps/offenderevents/e2e/HMPPSDomainEventsIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/hmpps/offenderevents/e2e/HMPPSDomainEventsIntTest.kt
@@ -7,7 +7,6 @@ import net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.within
 import org.assertj.core.api.ThrowingConsumer
-import org.assertj.core.data.TemporalUnitOffset
 import org.awaitility.Awaitility.await
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
@@ -20,11 +19,12 @@ import org.mockito.kotlin.verify
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.mock.mockito.SpyBean
-import org.springframework.test.util.JsonPathExpectationsHelper
 import software.amazon.awssdk.services.sns.model.MessageAttributeValue
 import software.amazon.awssdk.services.sns.model.PublishRequest
 import software.amazon.awssdk.services.sqs.model.Message
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest
+import uk.gov.justice.hmpps.offenderevents.helpers.assertJsonPath
+import uk.gov.justice.hmpps.offenderevents.helpers.assertJsonPathDateTimeIsCloseTo
 import uk.gov.justice.hmpps.offenderevents.resource.QueueListenerIntegrationTest
 import uk.gov.justice.hmpps.offenderevents.services.HMPPSDomainEventsEmitter
 import uk.gov.justice.hmpps.offenderevents.services.wiremock.HMPPSAuthExtension
@@ -593,13 +593,4 @@ class HMPPSDomainEventsIntTest : QueueListenerIntegrationTest() {
       }
     }
   }
-}
-
-private fun String.assertJsonPath(path: String, expectedValue: Any) = JsonPathExpectationsHelper(path).assertValue(this, expectedValue)
-
-private fun String.assertJsonPathDateTimeIsCloseTo(path: String, other: OffsetDateTime, offset: TemporalUnitOffset) {
-  val value = JsonPathExpectationsHelper(path).evaluateJsonPath(this)
-  assertThat(value).isNotNull
-  assertThat(OffsetDateTime.parse(value!!.toString()))
-    .isCloseTo(other, offset)
 }

--- a/src/test/kotlin/uk/gov/justice/hmpps/offenderevents/helpers/AssertJsonPath.kt
+++ b/src/test/kotlin/uk/gov/justice/hmpps/offenderevents/helpers/AssertJsonPath.kt
@@ -1,0 +1,15 @@
+package uk.gov.justice.hmpps.offenderevents.helpers
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.data.TemporalUnitOffset
+import org.springframework.test.util.JsonPathExpectationsHelper
+import java.time.OffsetDateTime
+
+fun String.assertJsonPath(path: String, expectedValue: Any) = JsonPathExpectationsHelper(path).assertValue(this, expectedValue)
+
+fun String.assertJsonPathDateTimeIsCloseTo(path: String, other: OffsetDateTime, offset: TemporalUnitOffset) {
+  val value = JsonPathExpectationsHelper(path).evaluateJsonPath(this)
+  assertThat(value).isNotNull
+  assertThat(OffsetDateTime.parse(value!!.toString()))
+    .isCloseTo(other, offset)
+}


### PR DESCRIPTION
prison-offender-events.visitor.restriction.changed split into 2 events 

- prison-offender-events.visitor.restriction.upserted
- prison-offender-events.visitor.restriction.deleted

but prison-offender-events.visitor.restriction.changed kept for backward compatibility 

Also added documentation