### PR TITLE
BAVL-245 stop 'null' string value being put into the video appointment cancelled event when there is no end time in the APPOINTMENT_CHANGED event.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/hmpps/offenderevents/model/HmppsDomainEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/offenderevents/model/HmppsDomainEvent.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.hmpps.offenderevents.model
 import com.fasterxml.jackson.annotation.JsonInclude
 import software.amazon.awssdk.services.sns.model.MessageAttributeValue
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -33,6 +34,11 @@ data class HmppsDomainEvent(
 
   fun withAdditionalInformation(key: String, value: LocalDate?): HmppsDomainEvent {
     if (value != null) additionalInformation[key] = value.format(DateTimeFormatter.ISO_DATE)
+    return this
+  }
+
+  fun withAdditionalInformation(key: String, value: LocalDateTime?): HmppsDomainEvent {
+    if (value != null) additionalInformation[key] = value.format(DateTimeFormatter.ISO_DATE_TIME)
     return this
   }
 

--- a/src/main/kotlin/uk/gov/justice/hmpps/offenderevents/services/HMPPSDomainEventsEmitter.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/offenderevents/services/HMPPSDomainEventsEmitter.kt
@@ -526,8 +526,8 @@ class HMPPSDomainEventsEmitter(
             personReference = PersonReference(it),
           )
             .withAdditionalInformation("scheduleEventId", this.scheduleEventId)
-            .withAdditionalInformation("scheduledStartTime", this.scheduledStartTime.toString())
-            .withAdditionalInformation("scheduledEndTime", this.scheduledEndTime.toString())
+            .withAdditionalInformation("scheduledStartTime", this.scheduledStartTime)
+            .withAdditionalInformation("scheduledEndTime", this.scheduledEndTime)
             .withAdditionalInformation("scheduleEventSubType", this.scheduleEventSubType)
             .withAdditionalInformation("scheduleEventStatus", this.scheduleEventStatus)
             .withAdditionalInformation("recordDeleted", this.recordDeleted)

--- a/src/test/kotlin/uk/gov/justice/hmpps/offenderevents/e2e/HMPPSDomainEventsIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/hmpps/offenderevents/e2e/HMPPSDomainEventsIntTest.kt
@@ -528,8 +528,8 @@ class HMPPSDomainEventsIntTest : QueueListenerIntegrationTest() {
         assertJsonPath("additionalInformation.scheduleEventId").asString().isEqualTo("100")
         assertJsonPath("additionalInformation.scheduleEventSubType").isEqualTo("VLB")
         assertJsonPath("additionalInformation.scheduleEventStatus").isEqualTo("CANC")
-        assertJsonPath("additionalInformation.scheduledStartTime").isEqualTo("2024-07-08T10:15")
-        assertJsonPath("additionalInformation.scheduledEndTime").isEqualTo("2024-07-08T10:45")
+        assertJsonPath("additionalInformation.scheduledStartTime").isEqualTo("2024-07-08T10:15:00")
+        assertJsonPath("additionalInformation.scheduledEndTime").isEqualTo("2024-07-08T10:45:00")
         assertJsonPath("additionalInformation.recordDeleted").isEqualTo("true")
         assertJsonPath("additionalInformation.agencyLocationId").isEqualTo("MDI")
       }


### PR DESCRIPTION
**NOTE: this is only being used by the re-platformed BVLS service at time of writing.**

Was putting in the actual string value of `"null"` when mapping the APPOINTMENT_CHANGED event field `scheduledEndTime`.

No value should be put in if the `scheduledEndTime` is essentially null (not present).