### PR TITLE
new fix for "SDIT-3760 prison-offender-events.prisoner.received should not be suppressed by a TAP"

### DIFF
--- a/src/main/kotlin/uk/gov/justice/hmpps/offenderevents/model/OffenderEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/offenderevents/model/OffenderEvent.kt
@@ -37,6 +37,8 @@ class CellMoveOffenderEvent(
 class PrisonerReceivedOffenderEvent(
   eventDatetime: LocalDateTime,
   override val offenderIdDisplay: String,
+  val bookingId: Long? = null,
+  val movementSeq: Int? = null,
 ) : OffenderEvent(eventDatetime = eventDatetime, offenderIdDisplay = offenderIdDisplay) {
   companion object
 }

--- a/src/main/kotlin/uk/gov/justice/hmpps/offenderevents/services/HMPPSDomainEventsEmitter.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/offenderevents/services/HMPPSDomainEventsEmitter.kt
@@ -205,7 +205,7 @@ class HMPPSDomainEventsEmitter(
       }
       throw e
     }
-    if (!releaseReason.hasPrisonerActuallyBeenRelease()) {
+    if (!releaseReason.hasPrisonerActuallyBeenReleased()) {
       telemetryClient.trackEvent(
         "prison-offender-events.prisoner.not-released",
         asTelemetryMap(this, releaseReason, releaseReason.reason.name),

--- a/src/main/kotlin/uk/gov/justice/hmpps/offenderevents/services/HMPPSDomainEventsEmitter.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/offenderevents/services/HMPPSDomainEventsEmitter.kt
@@ -154,7 +154,7 @@ class HMPPSDomainEventsEmitter(
   private fun PrisonerReceivedOffenderEvent.toDomainEvent(): HmppsDomainEvent? {
     val offenderNumber = this.offenderIdDisplay
     val receivedReason: ReceiveReason = try {
-      receivePrisonerReasonCalculator.calculateMostLikelyReasonForPrisonerReceive(offenderNumber)
+      receivePrisonerReasonCalculator.calculateMostLikelyReasonForPrisonerReceive(this)
     } catch (e: WebClientResponseException) {
       if (e.statusCode == HttpStatus.NOT_FOUND) {
         // Possibly the offender has been merged since the receive event

--- a/src/main/kotlin/uk/gov/justice/hmpps/offenderevents/services/PrisonApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/offenderevents/services/PrisonApiService.kt
@@ -1,27 +1,22 @@
 package uk.gov.justice.hmpps.offenderevents.services
 
+import io.swagger.v3.oas.annotations.media.Schema
 import org.springframework.beans.factory.annotation.Value
-import org.springframework.core.ParameterizedTypeReference
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.bodyToMono
+import uk.gov.justice.hmpps.offenderevents.services.PrisonerDetails.Companion.LICENCE_REVOKED
+import uk.gov.justice.hmpps.offenderevents.services.PrisonerDetails.Companion.RECALL_FROM_DETENTION_TRAINING_ORDER
+import uk.gov.justice.hmpps.offenderevents.services.PrisonerDetails.Companion.RECALL_FROM_HDC
+import uk.gov.justice.hmpps.offenderevents.services.PrisonerDetails.Companion.TRANSFER_IN
+import uk.gov.justice.hmpps.offenderevents.services.PrisonerDetails.Companion.TRANSFER_IN_VIA_COURT
+import uk.gov.justice.hmpps.offenderevents.services.PrisonerDetails.Companion.TRANSFER_IN_VIA_TAP
+import uk.gov.justice.hmpps.offenderevents.services.PrisonerDetails.Companion.UNCONVICTED_REMAND
 import java.time.Duration
+import java.time.LocalDateTime
 import java.util.Optional
 
-internal enum class LegalStatus {
-  RECALL,
-  DEAD,
-  INDETERMINATE_SENTENCE,
-  SENTENCED,
-  CONVICTED_UNSENTENCED,
-  CIVIL_PRISONER,
-  IMMIGRATION_DETAINEE,
-  REMAND,
-  UNKNOWN,
-  OTHER,
-}
-
-internal enum class MovementType {
+enum class MovementType {
   TEMPORARY_ABSENCE,
   COURT,
   ADMISSION,
@@ -30,7 +25,7 @@ internal enum class MovementType {
   OTHER,
 }
 
-internal enum class MovementReason {
+enum class MovementReason {
   HOSPITALISATION,
   TRANSFER,
   RECALL,
@@ -41,7 +36,7 @@ internal enum class MovementReason {
 @Service
 class PrisonApiService(
   private val prisonApiWebClient: WebClient,
-  @Value("\${api.prisoner-timeout:30s}") private val timeout: Duration,
+  @Value($$"${api.prisoner-timeout:30s}") private val timeout: Duration,
 ) {
   internal fun getPrisonerDetails(offenderNumber: String): PrisonerDetails = prisonApiWebClient.get()
     .uri("/api/offenders/{offenderNumber}", offenderNumber)
@@ -61,21 +56,23 @@ class PrisonApiService(
   internal fun getIdentifiersByBookingId(bookingId: Long?): List<BookingIdentifier>? = prisonApiWebClient.get()
     .uri("/api/bookings/{bookingId}/identifiers?type=MERGED", bookingId)
     .retrieve()
-    .bodyToMono<List<BookingIdentifier>>(object : ParameterizedTypeReference<List<BookingIdentifier>>() {})
+    .bodyToMono<List<BookingIdentifier>>()
     .block(timeout)
+
+  fun getMovementsByBooking(bookingId: Long): List<BookingMovement> = prisonApiWebClient.get()
+    .uri("/api/movements/booking/{bookingId}", bookingId)
+    .retrieve()
+    .bodyToMono<List<BookingMovement>>()
+    .block(timeout)!!
 }
 
 internal data class PrisonerDetails(
-  private val legalStatus: LegalStatus?,
-  val recall: Boolean,
   val lastMovementTypeCode: String,
   val lastMovementReasonCode: String,
-  val status: String?,
-  val statusReason: String,
-  val latestLocationId: String,
+  val status: String?, // e.g. 'ACTIVE IN'
+  val statusReason: String, // type-reason, e.g. TAP-OPA
+  val latestLocationId: String, // prison e.g. SWI
 ) {
-  fun legalStatus(): LegalStatus = legalStatus ?: LegalStatus.UNKNOWN
-
   fun typeOfMovement(): MovementType = when (lastMovementTypeCode) {
     "TAP" -> MovementType.TEMPORARY_ABSENCE
     "ADM" -> MovementType.ADMISSION
@@ -138,3 +135,51 @@ internal data class PrisonerDetails(
 
 internal data class BookingIdentifier(val value: String)
 internal data class BasicBookingDetail(val offenderNo: String)
+
+data class BookingMovement(
+  @Schema(description = "Sequence number")
+  val sequence: Int?,
+
+  @Schema(description = "Agency travelling from")
+  val fromAgency: String? = null,
+
+  @Schema(description = "Agency travelling to")
+  val toAgency: String? = null,
+
+  @Schema(
+    allowableValues = ["ADM", "CRT", "REL", "TAP", "TRN"],
+  )
+  val movementType: String? = null,
+
+  @Schema(description = "IN or OUT")
+  val directionCode: String? = null,
+
+  @Schema(description = "Movement timestamp")
+  val movementDateTime: LocalDateTime? = null,
+
+  @Schema(description = "Code of movement reason")
+  val movementReasonCode: String? = null,
+
+  @Schema(description = "DB create timestamp")
+  val createdDateTime: LocalDateTime? = null,
+
+  @Schema(description = "DB modify timestamp")
+  val modifiedDateTime: LocalDateTime? = null,
+) {
+  fun typeOfMovement(): MovementType = when (movementType) {
+    "TAP" -> MovementType.TEMPORARY_ABSENCE
+    "ADM" -> MovementType.ADMISSION
+    "REL" -> MovementType.RELEASED
+    "CRT" -> MovementType.COURT
+    "TRN" -> MovementType.TRANSFER
+    else -> MovementType.OTHER
+  }
+
+  fun movementReason(): MovementReason = when (movementReasonCode) {
+    "HP" -> MovementReason.HOSPITALISATION
+    TRANSFER_IN, TRANSFER_IN_VIA_COURT, TRANSFER_IN_VIA_TAP -> MovementReason.TRANSFER
+    LICENCE_REVOKED, RECALL_FROM_HDC, RECALL_FROM_DETENTION_TRAINING_ORDER -> MovementReason.RECALL
+    UNCONVICTED_REMAND -> MovementReason.REMAND
+    else -> MovementReason.OTHER
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/hmpps/offenderevents/services/PrisonApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/offenderevents/services/PrisonApiService.kt
@@ -69,27 +69,10 @@ class PrisonApiService(
 internal data class PrisonerDetails(
   val lastMovementTypeCode: String,
   val lastMovementReasonCode: String,
-  val status: String?, // e.g. 'ACTIVE IN'
-  val statusReason: String, // type-reason, e.g. TAP-OPA
-  val latestLocationId: String, // prison e.g. SWI
+  val status: String?,
+  val statusReason: String,
+  val latestLocationId: String,
 ) {
-  fun typeOfMovement(): MovementType = when (lastMovementTypeCode) {
-    "TAP" -> MovementType.TEMPORARY_ABSENCE
-    "ADM" -> MovementType.ADMISSION
-    "REL" -> MovementType.RELEASED
-    "CRT" -> MovementType.COURT
-    "TRN" -> MovementType.TRANSFER
-    else -> MovementType.OTHER
-  }
-
-  fun movementReason(): MovementReason = when (lastMovementReasonCode) {
-    "HP" -> MovementReason.HOSPITALISATION
-    TRANSFER_IN, TRANSFER_IN_VIA_COURT, TRANSFER_IN_VIA_TAP -> MovementReason.TRANSFER
-    LICENCE_REVOKED, RECALL_FROM_HDC, RECALL_FROM_DETENTION_TRAINING_ORDER -> MovementReason.RECALL
-    UNCONVICTED_REMAND -> MovementReason.REMAND
-    else -> MovementReason.OTHER
-  }
-
   fun currentLocation(): CurrentLocation? = status?.let { secondOf(it) }
     ?.let {
       when (it) {
@@ -165,21 +148,21 @@ data class BookingMovement(
 
   @Schema(description = "DB modify timestamp")
   val modifiedDateTime: LocalDateTime? = null,
-) {
-  fun typeOfMovement(): MovementType = when (movementType) {
-    "TAP" -> MovementType.TEMPORARY_ABSENCE
-    "ADM" -> MovementType.ADMISSION
-    "REL" -> MovementType.RELEASED
-    "CRT" -> MovementType.COURT
-    "TRN" -> MovementType.TRANSFER
-    else -> MovementType.OTHER
-  }
+)
 
-  fun movementReason(): MovementReason = when (movementReasonCode) {
-    "HP" -> MovementReason.HOSPITALISATION
-    TRANSFER_IN, TRANSFER_IN_VIA_COURT, TRANSFER_IN_VIA_TAP -> MovementReason.TRANSFER
-    LICENCE_REVOKED, RECALL_FROM_HDC, RECALL_FROM_DETENTION_TRAINING_ORDER -> MovementReason.RECALL
-    UNCONVICTED_REMAND -> MovementReason.REMAND
-    else -> MovementReason.OTHER
-  }
+fun typeOfMovement(movementTypeCode: String?): MovementType = when (movementTypeCode) {
+  "TAP" -> MovementType.TEMPORARY_ABSENCE
+  "ADM" -> MovementType.ADMISSION
+  "REL" -> MovementType.RELEASED
+  "CRT" -> MovementType.COURT
+  "TRN" -> MovementType.TRANSFER
+  else -> MovementType.OTHER
+}
+
+fun movementReason(movementReasonCode: String?): MovementReason = when (movementReasonCode) {
+  "HP" -> MovementReason.HOSPITALISATION
+  TRANSFER_IN, TRANSFER_IN_VIA_COURT, TRANSFER_IN_VIA_TAP -> MovementReason.TRANSFER
+  LICENCE_REVOKED, RECALL_FROM_HDC, RECALL_FROM_DETENTION_TRAINING_ORDER -> MovementReason.RECALL
+  UNCONVICTED_REMAND -> MovementReason.REMAND
+  else -> MovementReason.OTHER
 }

--- a/src/main/kotlin/uk/gov/justice/hmpps/offenderevents/services/ReceivePrisonerReasonCalculator.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/offenderevents/services/ReceivePrisonerReasonCalculator.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.hmpps.offenderevents.services
 
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
+import uk.gov.justice.hmpps.offenderevents.model.PrisonerReceivedOffenderEvent
 import uk.gov.justice.hmpps.offenderevents.services.CurrentLocation.IN_PRISON
 import uk.gov.justice.hmpps.offenderevents.services.MovementReason.TRANSFER
 
@@ -9,38 +10,35 @@ import uk.gov.justice.hmpps.offenderevents.services.MovementReason.TRANSFER
 class ReceivePrisonerReasonCalculator(
   private val prisonApiService: PrisonApiService,
 ) {
-  internal fun calculateMostLikelyReasonForPrisonerReceive(offenderNumber: String): ReceiveReason {
-    val prisonerDetails = prisonApiService.getPrisonerDetails(offenderNumber)
+  internal fun calculateMostLikelyReasonForPrisonerReceive(event: PrisonerReceivedOffenderEvent): ReceiveReason {
+    val prisonerDetails = prisonApiService.getPrisonerDetails(event.offenderIdDisplay)
+    val movements = event.bookingId?.let { prisonApiService.getMovementsByBooking(it) }
+    val receiveMovement = movements?.find { it.sequence == event.movementSeq }
 
-    val reason = when (prisonerDetails.typeOfMovement()) {
+    val reason = when (receiveMovement?.typeOfMovement()) {
       // They might not actually be in prison if they were received then went straight out on a TAP
       // or to court within the (usually 45 mins) grace period
 
-      MovementType.TEMPORARY_ABSENCE -> when (prisonerDetails.currentLocation()) {
-        IN_PRISON -> Reason.TEMPORARY_ABSENCE_RETURN
-        else -> Reason.ADMISSION
-      }
-
-      MovementType.COURT -> when (prisonerDetails.currentLocation()) {
-        IN_PRISON -> Reason.RETURN_FROM_COURT
-        else -> Reason.ADMISSION
-      }
-
-      MovementType.ADMISSION -> when (prisonerDetails.movementReason()) {
+      MovementType.TEMPORARY_ABSENCE -> Reason.TEMPORARY_ABSENCE_RETURN
+      MovementType.COURT -> Reason.RETURN_FROM_COURT
+      MovementType.ADMISSION -> when (receiveMovement.movementReason()) {
         TRANSFER -> Reason.TRANSFERRED
         else -> Reason.ADMISSION
       }
-
       else -> Reason.ADMISSION
     }
+    val status = receiveMovement?.let { "ACTIVE ${receiveMovement.directionCode}" } ?: prisonerDetails.status
+    val statusReason = receiveMovement?.let { "${receiveMovement.movementType}-${receiveMovement.movementReasonCode}" }
+      ?: prisonerDetails.statusReason
+    val nomisMovementReasonCode = receiveMovement?.movementReasonCode ?: prisonerDetails.lastMovementReasonCode
 
     return ReceiveReason(
       reason = reason,
-      details = "${prisonerDetails.status}:${prisonerDetails.statusReason}",
+      details = "$status:$statusReason",
       currentLocation = prisonerDetails.currentLocation(),
       currentPrisonStatus = prisonerDetails.currentPrisonStatus(),
       prisonId = prisonerDetails.latestLocationId,
-      nomisMovementReason = MovementReason(prisonerDetails.lastMovementReasonCode),
+      nomisMovementReason = MovementReason(nomisMovementReasonCode),
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/hmpps/offenderevents/services/ReceivePrisonerReasonCalculator.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/offenderevents/services/ReceivePrisonerReasonCalculator.kt
@@ -15,13 +15,10 @@ class ReceivePrisonerReasonCalculator(
     val movements = event.bookingId?.let { prisonApiService.getMovementsByBooking(it) }
     val receiveMovement = movements?.find { it.sequence == event.movementSeq }
 
-    val reason = when (receiveMovement?.typeOfMovement()) {
-      // They might not actually be in prison if they were received then went straight out on a TAP
-      // or to court within the (usually 45 mins) grace period
-
+    val reason = when (typeOfMovement(receiveMovement?.movementType)) {
       MovementType.TEMPORARY_ABSENCE -> Reason.TEMPORARY_ABSENCE_RETURN
       MovementType.COURT -> Reason.RETURN_FROM_COURT
-      MovementType.ADMISSION -> when (receiveMovement.movementReason()) {
+      MovementType.ADMISSION -> when (movementReason(receiveMovement?.movementReasonCode)) {
         TRANSFER -> Reason.TRANSFERRED
         else -> Reason.ADMISSION
       }

--- a/src/main/kotlin/uk/gov/justice/hmpps/offenderevents/services/ReceivePrisonerReasonCalculator.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/offenderevents/services/ReceivePrisonerReasonCalculator.kt
@@ -13,12 +13,24 @@ class ReceivePrisonerReasonCalculator(
     val prisonerDetails = prisonApiService.getPrisonerDetails(offenderNumber)
 
     val reason = when (prisonerDetails.typeOfMovement()) {
-      MovementType.TEMPORARY_ABSENCE -> Reason.TEMPORARY_ABSENCE_RETURN
-      MovementType.COURT -> Reason.RETURN_FROM_COURT
+      // They might not actually be in prison if they were received then went straight out on a TAP
+      // or to court within the (usually 45 mins) grace period
+
+      MovementType.TEMPORARY_ABSENCE -> when (prisonerDetails.currentLocation()) {
+        IN_PRISON -> Reason.TEMPORARY_ABSENCE_RETURN
+        else -> Reason.ADMISSION
+      }
+
+      MovementType.COURT -> when (prisonerDetails.currentLocation()) {
+        IN_PRISON -> Reason.RETURN_FROM_COURT
+        else -> Reason.ADMISSION
+      }
+
       MovementType.ADMISSION -> when (prisonerDetails.movementReason()) {
         TRANSFER -> Reason.TRANSFERRED
         else -> Reason.ADMISSION
       }
+
       else -> Reason.ADMISSION
     }
 
@@ -53,7 +65,7 @@ class ReceivePrisonerReasonCalculator(
       if ((currentLocation == IN_PRISON) != (currentPrisonStatus == CurrentPrisonStatus.UNDER_PRISON_CARE)) {
         log.warn("hasPrisonerActuallyBeenReceived(): verdict based on active differs from old for $this")
       }
-      return currentLocation == IN_PRISON
+      return currentPrisonStatus == CurrentPrisonStatus.UNDER_PRISON_CARE
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/hmpps/offenderevents/services/ReleasePrisonerReasonCalculator.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/offenderevents/services/ReleasePrisonerReasonCalculator.kt
@@ -80,6 +80,6 @@ class ReleasePrisonerReasonCalculator(private val prisonApiService: PrisonApiSer
     override val prisonId: String,
     val nomisMovementReason: MovementReason,
   ) : PrisonerMovementReason {
-    fun hasPrisonerActuallyBeenRelease(): Boolean = currentLocation != CurrentLocation.IN_PRISON
+    fun hasPrisonerActuallyBeenReleased(): Boolean = currentLocation != CurrentLocation.IN_PRISON
   }
 }

--- a/src/main/kotlin/uk/gov/justice/hmpps/offenderevents/services/ReleasePrisonerReasonCalculator.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/offenderevents/services/ReleasePrisonerReasonCalculator.kt
@@ -11,7 +11,7 @@ class ReleasePrisonerReasonCalculator(private val prisonApiService: PrisonApiSer
     val currentPrisonStatus = prisonerDetails.currentPrisonStatus()
     val latestLocationId = prisonerDetails.latestLocationId
     val nomisMovementReason = MovementReason(prisonerDetails.lastMovementReasonCode)
-    val reasonWithDetails = when (prisonerDetails.typeOfMovement()) {
+    val reasonWithDetails = when (typeOfMovement(prisonerDetails.lastMovementTypeCode)) {
       MovementType.TEMPORARY_ABSENCE -> ReasonWithDetails(
         reason = Reason.TEMPORARY_ABSENCE_RELEASE,
         nomisMovementReason = MovementReason(prisonerDetails.lastMovementReasonCode),
@@ -28,7 +28,7 @@ class ReleasePrisonerReasonCalculator(private val prisonApiService: PrisonApiSer
       )
 
       MovementType.RELEASED -> {
-        val reason = when (prisonerDetails.movementReason()) {
+        val reason = when (movementReason(prisonerDetails.lastMovementReasonCode)) {
           HOSPITALISATION -> Reason.RELEASED_TO_HOSPITAL
           else -> Reason.RELEASED
         }

--- a/src/test/kotlin/uk/gov/justice/hmpps/offenderevents/e2e/HMPPSDomainEventsIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/hmpps/offenderevents/e2e/HMPPSDomainEventsIntTest.kt
@@ -85,7 +85,7 @@ class HMPPSDomainEventsIntTest(@Autowired private val jsonMapper: JsonMapper) : 
         //language=JSON
         """
           {
-               "eventType":"OFFENDER_MOVEMENT-RECEPTION",
+              "eventType":"OFFENDER_MOVEMENT-RECEPTION",
               "eventDatetime":"2021-06-08T14:41:11.526762",
               "offenderIdDisplay":"A5194DY",
               "bookingId":1201234,
@@ -103,6 +103,24 @@ class HMPPSDomainEventsIntTest(@Autowired private val jsonMapper: JsonMapper) : 
       @BeforeEach
       fun setUp() {
         PrisonApiExtension.server.stubPrisonerDetails("A5194DY", "RECALL", true, "ADM", "R", "ACTIVE IN", "MDI")
+        PrisonApiExtension.server.stubGetMovementsByBooking(
+          1201234,
+          //language=JSON
+          """[
+            {
+              "sequence": 11,
+              "fromAgency": "SHEFCC",
+              "toAgency": "MDI",
+              "movementType": "ADM",
+              "directionCode": "IN",
+              "movementDateTime": "2023-02-10T08:11:00",
+              "movementReasonCode": "R",
+              "createdDateTime": "2023-02-10T08:11:22.685037",
+              "modifiedDateTime": "2023-02-10T14:19:14.560498"
+            }
+            ]
+          """.trimIndent(),
+        )
       }
 
       @Test
@@ -123,10 +141,11 @@ class HMPPSDomainEventsIntTest(@Autowired private val jsonMapper: JsonMapper) : 
           assertJsonPath("occurredAt", "2021-06-08T14:41:11.526762+01:00")
           assertJsonPathDateTimeIsCloseTo("publishedAt", OffsetDateTime.now(), within(10, ChronoUnit.SECONDS))
           assertJsonPath("additionalInformation.reason").isEqualTo("ADMISSION")
-          assertJsonPath("additionalInformation.prisonId").isEqualTo("MDI")
+          assertJsonPath("additionalInformation.details").isEqualTo("ACTIVE IN:ADM-R")
           assertJsonPath("additionalInformation.currentLocation").isEqualTo("IN_PRISON")
-          assertJsonPath("additionalInformation.currentPrisonStatus")
-            .isEqualTo("UNDER_PRISON_CARE")
+          assertJsonPath("additionalInformation.prisonId").isEqualTo("MDI")
+          assertJsonPath("additionalInformation.nomisMovementReasonCode").isEqualTo("R")
+          assertJsonPath("additionalInformation.currentPrisonStatus").isEqualTo("UNDER_PRISON_CARE")
         }
       }
     }

--- a/src/test/kotlin/uk/gov/justice/hmpps/offenderevents/services/PrisonApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/hmpps/offenderevents/services/PrisonApiServiceTest.kt
@@ -16,7 +16,6 @@ import uk.gov.justice.hmpps.offenderevents.services.CurrentLocation.IN_PRISON
 import uk.gov.justice.hmpps.offenderevents.services.CurrentLocation.OUTSIDE_PRISON
 import uk.gov.justice.hmpps.offenderevents.services.CurrentPrisonStatus.NOT_UNDER_PRISON_CARE
 import uk.gov.justice.hmpps.offenderevents.services.CurrentPrisonStatus.UNDER_PRISON_CARE
-import uk.gov.justice.hmpps.offenderevents.services.LegalStatus.REMAND
 import uk.gov.justice.hmpps.offenderevents.services.wiremock.HMPPSAuthExtension
 import uk.gov.justice.hmpps.offenderevents.services.wiremock.PrisonApiExtension
 import uk.gov.justice.hmpps.offenderevents.services.wiremock.PrisonApiExtension.Companion.server
@@ -51,20 +50,6 @@ internal class PrisonApiServiceTest {
         WireMock.getRequestedFor(WireMock.urlEqualTo("/api/offenders/A7841DY"))
           .withHeader("Authorization", equalTo("Bearer ABCDE")),
       )
-    }
-
-    @Test
-    @DisplayName("can parse the legal status")
-    fun canParseTheLegalStatus() {
-      val prisonerDetails = service.getPrisonerDetails("A7841DY")
-      assertThat(prisonerDetails.legalStatus()).isEqualTo(REMAND)
-    }
-
-    @Test
-    @DisplayName("can parse the recall status")
-    fun canParseTheRecallStatus() {
-      val prisonerDetails = service.getPrisonerDetails("A7841DY")
-      assertThat(prisonerDetails.recall).isFalse
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/hmpps/offenderevents/services/ReceivePrisonerReasonCalculatorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/hmpps/offenderevents/services/ReceivePrisonerReasonCalculatorTest.kt
@@ -1,12 +1,12 @@
 package uk.gov.justice.hmpps.offenderevents.services
 
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import uk.gov.justice.hmpps.offenderevents.services.ReceivePrisonerReasonCalculator.Reason
 
 internal class ReceivePrisonerReasonCalculatorTest {
   private val prisonApiService: PrisonApiService = mock()
@@ -18,12 +18,12 @@ internal class ReceivePrisonerReasonCalculatorTest {
     whenever(prisonApiService.getPrisonerDetails(any()))
       .thenReturn(prisonerDetails("RECALL", true, "ADM"))
     assertThat(calculator.calculateMostLikelyReasonForPrisonerReceive("A1234GH").reason)
-      .isEqualTo(ReceivePrisonerReasonCalculator.Reason.ADMISSION)
+      .isEqualTo(Reason.ADMISSION)
 
     whenever(prisonApiService.getPrisonerDetails(any()))
       .thenReturn(prisonerDetails("RECALL", true, "TAP"))
     assertThat(calculator.calculateMostLikelyReasonForPrisonerReceive("A1234GH").reason)
-      .isEqualTo(ReceivePrisonerReasonCalculator.Reason.TEMPORARY_ABSENCE_RETURN)
+      .isEqualTo(Reason.TEMPORARY_ABSENCE_RETURN)
   }
 
   @Test
@@ -32,11 +32,11 @@ internal class ReceivePrisonerReasonCalculatorTest {
     whenever(prisonApiService.getPrisonerDetails(any()))
       .thenReturn(prisonerDetails("RECALL", true, "ADM"))
     assertThat(calculator.calculateMostLikelyReasonForPrisonerReceive("A1234GH").reason)
-      .isEqualTo(ReceivePrisonerReasonCalculator.Reason.ADMISSION)
+      .isEqualTo(Reason.ADMISSION)
     whenever(prisonApiService.getPrisonerDetails(any()))
       .thenReturn(prisonerDetails("RECALL", true, "CRT"))
     assertThat(calculator.calculateMostLikelyReasonForPrisonerReceive("A1234GH").reason)
-      .isEqualTo(ReceivePrisonerReasonCalculator.Reason.RETURN_FROM_COURT)
+      .isEqualTo(Reason.RETURN_FROM_COURT)
   }
 
   @Test
@@ -45,13 +45,13 @@ internal class ReceivePrisonerReasonCalculatorTest {
     whenever(prisonApiService.getPrisonerDetails(any()))
       .thenReturn(prisonerDetails("RECALL", true, "ADM", "L"))
     assertThat(calculator.calculateMostLikelyReasonForPrisonerReceive("A1234GH").reason)
-      .isEqualTo(ReceivePrisonerReasonCalculator.Reason.ADMISSION)
+      .isEqualTo(Reason.ADMISSION)
     assertThat(calculator.calculateMostLikelyReasonForPrisonerReceive("A1234GH").nomisMovementReason.code)
       .isEqualTo("L")
     whenever(prisonApiService.getPrisonerDetails(any()))
       .thenReturn(prisonerDetails("RECALL", true, "ADM", "INT"))
     assertThat(calculator.calculateMostLikelyReasonForPrisonerReceive("A1234GH").reason)
-      .isEqualTo(ReceivePrisonerReasonCalculator.Reason.TRANSFERRED)
+      .isEqualTo(Reason.TRANSFERRED)
     assertThat(calculator.calculateMostLikelyReasonForPrisonerReceive("A1234GH").nomisMovementReason.code)
       .isEqualTo("INT")
   }
@@ -62,13 +62,13 @@ internal class ReceivePrisonerReasonCalculatorTest {
     whenever(prisonApiService.getPrisonerDetails(any()))
       .thenReturn(prisonerDetails("RECALL", true, "ADM", "L"))
     assertThat(calculator.calculateMostLikelyReasonForPrisonerReceive("A1234GH").reason)
-      .isEqualTo(ReceivePrisonerReasonCalculator.Reason.ADMISSION)
+      .isEqualTo(Reason.ADMISSION)
     assertThat(calculator.calculateMostLikelyReasonForPrisonerReceive("A1234GH").nomisMovementReason.code)
       .isEqualTo("L")
     whenever(prisonApiService.getPrisonerDetails(any()))
       .thenReturn(prisonerDetails("RECALL", true, "ADM", "TRNCRT"))
     assertThat(calculator.calculateMostLikelyReasonForPrisonerReceive("A1234GH").reason)
-      .isEqualTo(ReceivePrisonerReasonCalculator.Reason.TRANSFERRED)
+      .isEqualTo(Reason.TRANSFERRED)
     assertThat(calculator.calculateMostLikelyReasonForPrisonerReceive("A1234GH").nomisMovementReason.code)
       .isEqualTo("TRNCRT")
   }
@@ -79,13 +79,13 @@ internal class ReceivePrisonerReasonCalculatorTest {
     whenever(prisonApiService.getPrisonerDetails(any()))
       .thenReturn(prisonerDetails("RECALL", true, "ADM", "L"))
     assertThat(calculator.calculateMostLikelyReasonForPrisonerReceive("A1234GH").reason)
-      .isEqualTo(ReceivePrisonerReasonCalculator.Reason.ADMISSION)
+      .isEqualTo(Reason.ADMISSION)
     assertThat(calculator.calculateMostLikelyReasonForPrisonerReceive("A1234GH").nomisMovementReason.code)
       .isEqualTo("L")
     whenever(prisonApiService.getPrisonerDetails(any()))
       .thenReturn(prisonerDetails("RECALL", true, "ADM", "TRNTAP"))
     assertThat(calculator.calculateMostLikelyReasonForPrisonerReceive("A1234GH").reason)
-      .isEqualTo(ReceivePrisonerReasonCalculator.Reason.TRANSFERRED)
+      .isEqualTo(Reason.TRANSFERRED)
     assertThat(calculator.calculateMostLikelyReasonForPrisonerReceive("A1234GH").nomisMovementReason.code)
       .isEqualTo("TRNTAP")
   }
@@ -109,7 +109,6 @@ internal class ReceivePrisonerReasonCalculatorTest {
   }
 
   @Test
-  @Disabled("Needs a rethink, coming soon")
   fun `when current status indicates out on TAP they are still really received`() {
     whenever(prisonApiService.getPrisonerDetails(any()))
       .thenReturn(
@@ -123,8 +122,28 @@ internal class ReceivePrisonerReasonCalculatorTest {
           "MDI",
         ),
       )
-    assertThat(calculator.calculateMostLikelyReasonForPrisonerReceive("A1234GH").hasPrisonerActuallyBeenReceived())
-      .isTrue()
+    val reason = calculator.calculateMostLikelyReasonForPrisonerReceive("A1234GH")
+    assertThat(reason.hasPrisonerActuallyBeenReceived()).isTrue()
+    assertThat(reason.reason).isEqualTo(Reason.ADMISSION)
+  }
+
+  @Test
+  fun `when current status indicates out at court they are still really received`() {
+    whenever(prisonApiService.getPrisonerDetails(any()))
+      .thenReturn(
+        PrisonerDetails(
+          LegalStatus.REMAND,
+          false,
+          "CRT",
+          "DC",
+          "ACTIVE OUT",
+          "CRT-DC",
+          "MDI",
+        ),
+      )
+    val reason = calculator.calculateMostLikelyReasonForPrisonerReceive("A1234GH")
+    assertThat(reason.hasPrisonerActuallyBeenReceived()).isTrue()
+    assertThat(reason.reason).isEqualTo(Reason.ADMISSION)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/hmpps/offenderevents/services/ReceivePrisonerReasonCalculatorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/hmpps/offenderevents/services/ReceivePrisonerReasonCalculatorTest.kt
@@ -6,142 +6,202 @@ import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import uk.gov.justice.hmpps.offenderevents.model.PrisonerReceivedOffenderEvent
 import uk.gov.justice.hmpps.offenderevents.services.ReceivePrisonerReasonCalculator.Reason
+import java.time.LocalDateTime
 
 internal class ReceivePrisonerReasonCalculatorTest {
   private val prisonApiService: PrisonApiService = mock()
   private val calculator: ReceivePrisonerReasonCalculator = ReceivePrisonerReasonCalculator(prisonApiService)
 
+  private val event = PrisonerReceivedOffenderEvent(
+    eventDatetime = LocalDateTime.now(),
+    offenderIdDisplay = "A1234GH",
+    bookingId = 1234567,
+    movementSeq = 1,
+  )
+
   @Test
   @DisplayName("TAP movement type")
   fun tAPMovementTypeTakesPrecedenceOverRecall() {
-    whenever(prisonApiService.getPrisonerDetails(any()))
-      .thenReturn(prisonerDetails("RECALL", true, "ADM"))
-    assertThat(calculator.calculateMostLikelyReasonForPrisonerReceive("A1234GH").reason)
-      .isEqualTo(Reason.ADMISSION)
+    whenever(prisonApiService.getPrisonerDetails(any())).thenReturn(prisonerDetails("ADM"))
+    whenever(prisonApiService.getMovementsByBooking(any())).thenReturn(
+      listOf(BookingMovement(sequence = 1, movementType = "ADM", movementReasonCode = "L")),
+    )
+    assertThat(calculator.calculateMostLikelyReasonForPrisonerReceive(event).reason).isEqualTo(Reason.ADMISSION)
 
-    whenever(prisonApiService.getPrisonerDetails(any()))
-      .thenReturn(prisonerDetails("RECALL", true, "TAP"))
-    assertThat(calculator.calculateMostLikelyReasonForPrisonerReceive("A1234GH").reason)
-      .isEqualTo(Reason.TEMPORARY_ABSENCE_RETURN)
+    whenever(prisonApiService.getPrisonerDetails(any())).thenReturn(prisonerDetails("TAP"))
+    whenever(prisonApiService.getMovementsByBooking(any())).thenReturn(
+      listOf(BookingMovement(sequence = 1, movementType = "TAP", movementReasonCode = "C1")),
+    )
+    assertThat(calculator.calculateMostLikelyReasonForPrisonerReceive(event).reason).isEqualTo(Reason.TEMPORARY_ABSENCE_RETURN)
   }
 
   @Test
   @DisplayName("COURT movement type")
   fun courtMovementTypeTakesPrecedenceOverRecall() {
-    whenever(prisonApiService.getPrisonerDetails(any()))
-      .thenReturn(prisonerDetails("RECALL", true, "ADM"))
-    assertThat(calculator.calculateMostLikelyReasonForPrisonerReceive("A1234GH").reason)
-      .isEqualTo(Reason.ADMISSION)
-    whenever(prisonApiService.getPrisonerDetails(any()))
-      .thenReturn(prisonerDetails("RECALL", true, "CRT"))
-    assertThat(calculator.calculateMostLikelyReasonForPrisonerReceive("A1234GH").reason)
-      .isEqualTo(Reason.RETURN_FROM_COURT)
+    whenever(prisonApiService.getPrisonerDetails(any())).thenReturn(prisonerDetails("ADM"))
+    whenever(prisonApiService.getMovementsByBooking(any())).thenReturn(
+      listOf(BookingMovement(sequence = 1, movementType = "ADM", movementReasonCode = "V")),
+    )
+    assertThat(calculator.calculateMostLikelyReasonForPrisonerReceive(event).reason).isEqualTo(Reason.ADMISSION)
+
+    whenever(prisonApiService.getPrisonerDetails(any())).thenReturn(prisonerDetails("CRT"))
+    whenever(prisonApiService.getMovementsByBooking(any())).thenReturn(
+      listOf(BookingMovement(sequence = 1, movementType = "CRT", movementReasonCode = "C1")),
+    )
+    assertThat(calculator.calculateMostLikelyReasonForPrisonerReceive(event).reason).isEqualTo(Reason.RETURN_FROM_COURT)
   }
 
   @Test
   @DisplayName("movement reason of INT means reason is a TRANSFER")
   fun movementReasonOfINTMeansReasonIsATRANSFER() {
-    whenever(prisonApiService.getPrisonerDetails(any()))
-      .thenReturn(prisonerDetails("RECALL", true, "ADM", "L"))
-    assertThat(calculator.calculateMostLikelyReasonForPrisonerReceive("A1234GH").reason)
-      .isEqualTo(Reason.ADMISSION)
-    assertThat(calculator.calculateMostLikelyReasonForPrisonerReceive("A1234GH").nomisMovementReason.code)
-      .isEqualTo("L")
-    whenever(prisonApiService.getPrisonerDetails(any()))
-      .thenReturn(prisonerDetails("RECALL", true, "ADM", "INT"))
-    assertThat(calculator.calculateMostLikelyReasonForPrisonerReceive("A1234GH").reason)
-      .isEqualTo(Reason.TRANSFERRED)
-    assertThat(calculator.calculateMostLikelyReasonForPrisonerReceive("A1234GH").nomisMovementReason.code)
-      .isEqualTo("INT")
+    whenever(prisonApiService.getPrisonerDetails(any())).thenReturn(prisonerDetails("ADM", "L"))
+    whenever(prisonApiService.getMovementsByBooking(any())).thenReturn(
+      listOf(BookingMovement(sequence = 1, movementType = "ADM", movementReasonCode = "L", directionCode = "IN")),
+    )
+    with(calculator.calculateMostLikelyReasonForPrisonerReceive(event)) {
+      assertThat(reason).isEqualTo(Reason.ADMISSION)
+      assertThat(details).isEqualTo("ACTIVE IN:ADM-L")
+      assertThat(currentLocation).isEqualTo(CurrentLocation.IN_PRISON)
+      assertThat(currentPrisonStatus).isEqualTo(CurrentPrisonStatus.UNDER_PRISON_CARE)
+      assertThat(prisonId).isEqualTo("MDI")
+      assertThat(nomisMovementReason.code).isEqualTo("L")
+    }
+
+    whenever(prisonApiService.getPrisonerDetails(any())).thenReturn(prisonerDetails("ADM", "INT"))
+    whenever(prisonApiService.getMovementsByBooking(any())).thenReturn(
+      listOf(BookingMovement(sequence = 1, movementType = "ADM", movementReasonCode = "INT")),
+    )
+    with(calculator.calculateMostLikelyReasonForPrisonerReceive(event)) {
+      assertThat(reason).isEqualTo(Reason.TRANSFERRED)
+      assertThat(nomisMovementReason.code).isEqualTo("INT")
+    }
   }
 
   @Test
   @DisplayName("movement reason of TRNCRT (transfer via court) means reason is a TRANSFER")
   fun movementReasonOfTRNCRTMeansReasonIsATRANSFER() {
-    whenever(prisonApiService.getPrisonerDetails(any()))
-      .thenReturn(prisonerDetails("RECALL", true, "ADM", "L"))
-    assertThat(calculator.calculateMostLikelyReasonForPrisonerReceive("A1234GH").reason)
-      .isEqualTo(Reason.ADMISSION)
-    assertThat(calculator.calculateMostLikelyReasonForPrisonerReceive("A1234GH").nomisMovementReason.code)
-      .isEqualTo("L")
-    whenever(prisonApiService.getPrisonerDetails(any()))
-      .thenReturn(prisonerDetails("RECALL", true, "ADM", "TRNCRT"))
-    assertThat(calculator.calculateMostLikelyReasonForPrisonerReceive("A1234GH").reason)
-      .isEqualTo(Reason.TRANSFERRED)
-    assertThat(calculator.calculateMostLikelyReasonForPrisonerReceive("A1234GH").nomisMovementReason.code)
-      .isEqualTo("TRNCRT")
+    whenever(prisonApiService.getPrisonerDetails(any())).thenReturn(prisonerDetails("ADM"))
+    whenever(prisonApiService.getMovementsByBooking(any())).thenReturn(
+      listOf(BookingMovement(sequence = 1, movementType = "ADM", movementReasonCode = "L")),
+    )
+    with(calculator.calculateMostLikelyReasonForPrisonerReceive(event)) {
+      assertThat(reason).isEqualTo(Reason.ADMISSION)
+      assertThat(nomisMovementReason.code).isEqualTo("L")
+    }
+
+    whenever(prisonApiService.getPrisonerDetails(any())).thenReturn(prisonerDetails("ADM"))
+    whenever(prisonApiService.getMovementsByBooking(any())).thenReturn(
+      listOf(BookingMovement(sequence = 1, movementType = "ADM", movementReasonCode = "TRNCRT")),
+    )
+    with(calculator.calculateMostLikelyReasonForPrisonerReceive(event)) {
+      assertThat(reason).isEqualTo(Reason.TRANSFERRED)
+      assertThat(nomisMovementReason.code).isEqualTo("TRNCRT")
+    }
   }
 
   @Test
   @DisplayName("movement reason of TRNTAP (transfer via TAP) means reason is a TRANSFER")
   fun movementReasonOfTRNTAPMeansReasonIsATRANSFER() {
-    whenever(prisonApiService.getPrisonerDetails(any()))
-      .thenReturn(prisonerDetails("RECALL", true, "ADM", "L"))
-    assertThat(calculator.calculateMostLikelyReasonForPrisonerReceive("A1234GH").reason)
-      .isEqualTo(Reason.ADMISSION)
-    assertThat(calculator.calculateMostLikelyReasonForPrisonerReceive("A1234GH").nomisMovementReason.code)
-      .isEqualTo("L")
-    whenever(prisonApiService.getPrisonerDetails(any()))
-      .thenReturn(prisonerDetails("RECALL", true, "ADM", "TRNTAP"))
-    assertThat(calculator.calculateMostLikelyReasonForPrisonerReceive("A1234GH").reason)
-      .isEqualTo(Reason.TRANSFERRED)
-    assertThat(calculator.calculateMostLikelyReasonForPrisonerReceive("A1234GH").nomisMovementReason.code)
-      .isEqualTo("TRNTAP")
+    whenever(prisonApiService.getPrisonerDetails(any())).thenReturn(prisonerDetails("ADM"))
+    whenever(prisonApiService.getMovementsByBooking(any())).thenReturn(
+      listOf(BookingMovement(sequence = 1, movementType = "ADM", movementReasonCode = "L")),
+    )
+    with(calculator.calculateMostLikelyReasonForPrisonerReceive(event)) {
+      assertThat(reason).isEqualTo(Reason.ADMISSION)
+      assertThat(nomisMovementReason.code).isEqualTo("L")
+    }
+
+    whenever(prisonApiService.getPrisonerDetails(any())).thenReturn(prisonerDetails("ADM"))
+    whenever(prisonApiService.getMovementsByBooking(any())).thenReturn(
+      listOf(BookingMovement(sequence = 1, movementType = "ADM", movementReasonCode = "TRNTAP")),
+    )
+    with(calculator.calculateMostLikelyReasonForPrisonerReceive(event)) {
+      assertThat(reason).isEqualTo(Reason.TRANSFERRED)
+      assertThat(nomisMovementReason.code).isEqualTo("TRNTAP")
+    }
   }
 
   @Test
   fun `when current status indicates in prison then they are really received`() {
-    whenever(prisonApiService.getPrisonerDetails(any()))
-      .thenReturn(
-        PrisonerDetails(
-          LegalStatus.REMAND,
-          false,
-          "ADM",
-          "L",
-          "ACTIVE IN",
-          "ADM-L",
-          "MDI",
-        ),
-      )
-    assertThat(calculator.calculateMostLikelyReasonForPrisonerReceive("A1234GH").hasPrisonerActuallyBeenReceived())
+    whenever(prisonApiService.getPrisonerDetails(any())).thenReturn(
+      PrisonerDetails(
+        "ADM",
+        "L",
+        "ACTIVE IN",
+        "ADM-L",
+        "MDI",
+      ),
+    )
+    assertThat(calculator.calculateMostLikelyReasonForPrisonerReceive(event).hasPrisonerActuallyBeenReceived())
       .isTrue()
   }
 
   @Test
   fun `when current status indicates out on TAP they are still really received`() {
     whenever(prisonApiService.getPrisonerDetails(any()))
-      .thenReturn(
-        PrisonerDetails(
-          LegalStatus.REMAND,
-          false,
-          "TAP",
-          "C6",
-          "ACTIVE OUT",
-          "TAP-C6",
-          "MDI",
+      .thenReturn(PrisonerDetails("TAP", "C6", "ACTIVE OUT", "TAP-C6", "MDI"))
+    whenever(prisonApiService.getMovementsByBooking(any())).thenReturn(
+      listOf(
+        BookingMovement(sequence = 1, movementType = "ADM", movementReasonCode = "L", directionCode = "IN"),
+        BookingMovement(sequence = 2, movementType = "TAP", movementReasonCode = "C6", directionCode = "OUT"),
+      ),
+    )
+    with(calculator.calculateMostLikelyReasonForPrisonerReceive(event)) {
+      assertThat(hasPrisonerActuallyBeenReceived()).isTrue()
+      assertThat(reason).isEqualTo(Reason.ADMISSION)
+      assertThat(details).isEqualTo("ACTIVE IN:ADM-L")
+      assertThat(currentLocation).isEqualTo(CurrentLocation.OUTSIDE_PRISON)
+      assertThat(currentPrisonStatus).isEqualTo(CurrentPrisonStatus.UNDER_PRISON_CARE)
+      assertThat(prisonId).isEqualTo("MDI")
+      assertThat(nomisMovementReason.code).isEqualTo("L")
+    }
+  }
+
+  @Test
+  fun `when they return from TAP but have gone out again immediately the reason is TAP`() {
+    whenever(prisonApiService.getPrisonerDetails(any()))
+      .thenReturn(PrisonerDetails("TAP", "C6", "ACTIVE OUT", "TAP-C6", "MDI"))
+    whenever(prisonApiService.getMovementsByBooking(any())).thenReturn(
+      listOf(
+        BookingMovement(sequence = 1, movementType = "ADM", movementReasonCode = "L", directionCode = "IN"),
+        BookingMovement(sequence = 2, movementType = "TAP", movementReasonCode = "C6", directionCode = "OUT"),
+        BookingMovement(sequence = 3, movementType = "TAP", movementReasonCode = "C6", directionCode = "IN"),
+        BookingMovement(sequence = 4, movementType = "TAP", movementReasonCode = "C7", directionCode = "OUT"),
+      ),
+    )
+    with(
+      calculator.calculateMostLikelyReasonForPrisonerReceive(
+        PrisonerReceivedOffenderEvent(
+          eventDatetime = LocalDateTime.now(),
+          offenderIdDisplay = "A1234GH",
+          bookingId = 1234567,
+          movementSeq = 3,
         ),
-      )
-    val reason = calculator.calculateMostLikelyReasonForPrisonerReceive("A1234GH")
-    assertThat(reason.hasPrisonerActuallyBeenReceived()).isTrue()
-    assertThat(reason.reason).isEqualTo(Reason.ADMISSION)
+      ),
+    ) {
+      assertThat(hasPrisonerActuallyBeenReceived()).isTrue()
+      assertThat(reason).isEqualTo(Reason.TEMPORARY_ABSENCE_RETURN)
+      assertThat(details).isEqualTo("ACTIVE IN:TAP-C6")
+      assertThat(currentLocation).isEqualTo(CurrentLocation.OUTSIDE_PRISON)
+      assertThat(currentPrisonStatus).isEqualTo(CurrentPrisonStatus.UNDER_PRISON_CARE)
+      assertThat(prisonId).isEqualTo("MDI")
+      assertThat(nomisMovementReason.code).isEqualTo("C6")
+    }
   }
 
   @Test
   fun `when current status indicates out at court they are still really received`() {
     whenever(prisonApiService.getPrisonerDetails(any()))
-      .thenReturn(
-        PrisonerDetails(
-          LegalStatus.REMAND,
-          false,
-          "CRT",
-          "DC",
-          "ACTIVE OUT",
-          "CRT-DC",
-          "MDI",
-        ),
-      )
-    val reason = calculator.calculateMostLikelyReasonForPrisonerReceive("A1234GH")
+      .thenReturn(PrisonerDetails("CRT", "DC", "ACTIVE OUT", "CRT-DC", "MDI"))
+    whenever(prisonApiService.getMovementsByBooking(any())).thenReturn(
+      listOf(
+        BookingMovement(sequence = 1, movementType = "ADM", movementReasonCode = "L", directionCode = "IN"),
+        BookingMovement(sequence = 2, movementType = "CRT", movementReasonCode = "DC", directionCode = "OUT"),
+      ),
+    )
+    val reason = calculator.calculateMostLikelyReasonForPrisonerReceive(event)
     assertThat(reason.hasPrisonerActuallyBeenReceived()).isTrue()
     assertThat(reason.reason).isEqualTo(Reason.ADMISSION)
   }
@@ -149,29 +209,21 @@ internal class ReceivePrisonerReasonCalculatorTest {
   @Test
   fun `when current status indicates not in prison then not really received`() {
     whenever(prisonApiService.getPrisonerDetails(any()))
-      .thenReturn(
-        PrisonerDetails(
-          LegalStatus.REMAND,
-          false,
-          "TRN",
-          "P",
-          "INACTIVE OUT",
-          "TRN-P",
-          "MDI",
-        ),
-      )
-    assertThat(calculator.calculateMostLikelyReasonForPrisonerReceive("A1234GH").hasPrisonerActuallyBeenReceived())
+      .thenReturn(PrisonerDetails("TRN", "P", "INACTIVE OUT", "TRN-P", "MDI"))
+    whenever(prisonApiService.getMovementsByBooking(any())).thenReturn(
+      listOf(
+        BookingMovement(sequence = 1, movementType = "TRN", movementReasonCode = "P", directionCode = "OUT"),
+      ),
+    )
+
+    assertThat(calculator.calculateMostLikelyReasonForPrisonerReceive(event).hasPrisonerActuallyBeenReceived())
       .isFalse()
   }
 
   private fun prisonerDetails(
-    legalStatus: String,
-    recall: Boolean,
     lastMovementTypeCode: String = "ADM",
     lastMovementReasonCode: String = "K",
   ): PrisonerDetails = PrisonerDetails(
-    LegalStatus.valueOf(legalStatus),
-    recall,
     lastMovementTypeCode,
     lastMovementReasonCode,
     "ACTIVE IN",

--- a/src/test/kotlin/uk/gov/justice/hmpps/offenderevents/services/ReleasePrisonerReasonCalculatorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/hmpps/offenderevents/services/ReleasePrisonerReasonCalculatorTest.kt
@@ -68,8 +68,6 @@ internal class ReleasePrisonerReasonCalculatorTest {
     whenever(prisonApiService.getPrisonerDetails(any()))
       .thenReturn(
         PrisonerDetails(
-          LegalStatus.REMAND,
-          false,
           "TRN",
           "P",
           "INACTIVE OUT",
@@ -81,8 +79,6 @@ internal class ReleasePrisonerReasonCalculatorTest {
     whenever(prisonApiService.getPrisonerDetails(any()))
       .thenReturn(
         PrisonerDetails(
-          LegalStatus.REMAND,
-          false,
           "REL",
           "P",
           "INACTIVE OUT",
@@ -94,8 +90,6 @@ internal class ReleasePrisonerReasonCalculatorTest {
     whenever(prisonApiService.getPrisonerDetails(any()))
       .thenReturn(
         PrisonerDetails(
-          LegalStatus.REMAND,
-          false,
           "ADM",
           "L",
           "ACTIVE IN",
@@ -107,8 +101,6 @@ internal class ReleasePrisonerReasonCalculatorTest {
   }
 
   private fun prisonerDetails(lastMovementTypCode: String, lastMovementReasonCode: String = "N"): PrisonerDetails = PrisonerDetails(
-    LegalStatus.SENTENCED,
-    false,
     lastMovementTypCode,
     lastMovementReasonCode,
     "ACTIVE OUT",

--- a/src/test/kotlin/uk/gov/justice/hmpps/offenderevents/services/ReleasePrisonerReasonCalculatorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/hmpps/offenderevents/services/ReleasePrisonerReasonCalculatorTest.kt
@@ -77,7 +77,7 @@ internal class ReleasePrisonerReasonCalculatorTest {
           "MDI",
         ),
       )
-    assertThat(calculator.calculateReasonForRelease("A1234GH").hasPrisonerActuallyBeenRelease()).isTrue()
+    assertThat(calculator.calculateReasonForRelease("A1234GH").hasPrisonerActuallyBeenReleased()).isTrue()
     whenever(prisonApiService.getPrisonerDetails(any()))
       .thenReturn(
         PrisonerDetails(
@@ -90,7 +90,7 @@ internal class ReleasePrisonerReasonCalculatorTest {
           "MDI",
         ),
       )
-    assertThat(calculator.calculateReasonForRelease("A1234GH").hasPrisonerActuallyBeenRelease()).isTrue()
+    assertThat(calculator.calculateReasonForRelease("A1234GH").hasPrisonerActuallyBeenReleased()).isTrue()
     whenever(prisonApiService.getPrisonerDetails(any()))
       .thenReturn(
         PrisonerDetails(
@@ -103,7 +103,7 @@ internal class ReleasePrisonerReasonCalculatorTest {
           "MDI",
         ),
       )
-    assertThat(calculator.calculateReasonForRelease("A1234GH").hasPrisonerActuallyBeenRelease()).isFalse()
+    assertThat(calculator.calculateReasonForRelease("A1234GH").hasPrisonerActuallyBeenReleased()).isFalse()
   }
 
   private fun prisonerDetails(lastMovementTypCode: String, lastMovementReasonCode: String = "N"): PrisonerDetails = PrisonerDetails(

--- a/src/test/kotlin/uk/gov/justice/hmpps/offenderevents/services/wiremock/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/hmpps/offenderevents/services/wiremock/PrisonApiMockServer.kt
@@ -2,10 +2,9 @@ package uk.gov.justice.hmpps.offenderevents.services.wiremock
 
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
-import java.util.function.Function
-import java.util.stream.Collectors
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.okJson
 
 class PrisonApiMockServer internal constructor() : WireMockServer(8086) {
   fun stubPrisonerDetails(
@@ -18,7 +17,7 @@ class PrisonApiMockServer internal constructor() : WireMockServer(8086) {
     latestLocationId: String,
   ) {
     stubFor(
-      WireMock.get(String.format("/api/offenders/%s", offenderNumber)).willReturn(
+      get(String.format("/api/offenders/%s", offenderNumber)).willReturn(
         WireMock.aResponse()
           .withHeader("Content-Type", "application/json")
           .withBody(
@@ -39,7 +38,7 @@ class PrisonApiMockServer internal constructor() : WireMockServer(8086) {
 
   fun stubPrisonerDetails404(offenderNumber: String?) {
     stubFor(
-      WireMock.get(String.format("/api/offenders/%s", offenderNumber)).willReturn(
+      get(String.format("/api/offenders/%s", offenderNumber)).willReturn(
         WireMock.aResponse()
           .withHeader("Content-Type", "application/json")
           .withStatus(404),
@@ -48,12 +47,12 @@ class PrisonApiMockServer internal constructor() : WireMockServer(8086) {
   }
 
   fun verifyPrisonerDetails404(offenderNumber: String?) {
-    verify(WireMock.getRequestedFor(WireMock.urlEqualTo(String.format("/api/offenders/%s", offenderNumber))))
+    verify(getRequestedFor(WireMock.urlEqualTo(String.format("/api/offenders/%s", offenderNumber))))
   }
 
   fun stubBasicPrisonerDetails(offenderNumber: String, bookingId: Long?) {
     stubFor(
-      WireMock.get(String.format("/api/bookings/%d?basicInfo=true&extraInfo=false", bookingId)).willReturn(
+      get(String.format("/api/bookings/%d?basicInfo=true&extraInfo=false", bookingId)).willReturn(
         WireMock.aResponse()
           .withHeader("Content-Type", "application/json")
           .withBody(basicPrisonerDetails(offenderNumber, bookingId))
@@ -64,7 +63,7 @@ class PrisonApiMockServer internal constructor() : WireMockServer(8086) {
 
   fun stubPrisonerIdentifiers(mergedNumber: String, bookingId: Long?) {
     stubFor(
-      WireMock.get(String.format("/api/bookings/%d/identifiers?type=MERGED", bookingId)).willReturn(
+      get(String.format("/api/bookings/%d/identifiers?type=MERGED", bookingId)).willReturn(
         WireMock.aResponse()
           .withHeader("Content-Type", "application/json")
           .withBody(mergeIdentifier(mergedNumber))
@@ -73,63 +72,47 @@ class PrisonApiMockServer internal constructor() : WireMockServer(8086) {
     )
   }
 
-  fun stubMovements(offenderNumber: String?, movements: List<MovementFragment>) {
-    val asJson = Function { (directionCode, movementDateTime): MovementFragment ->
-      val createDateTime = movementDateTime.format(
-        DateTimeFormatter.ISO_DATE_TIME,
-      )
-      val movementDate = movementDateTime
-        .toLocalDate()
-        .format(DateTimeFormatter.ISO_DATE)
-      val movementTime = movementDateTime
-        .toLocalTime()
-        .format(DateTimeFormatter.ISO_LOCAL_TIME)
-      String.format(
-        """
-                    {
-                        "offenderNo": "%s",
-                        "createDateTime": "%s",
-                        "fromAgency": "WWI",
-                        "fromAgencyDescription": "Wandsworth (HMP)",
-                        "toAgency": "FBI",
-                        "toAgencyDescription": "Forest Bank (HMP & YOI)",
-                        "fromCity": "",
-                        "toCity": "",
-                        "movementType": "%s",
-                        "movementTypeDescription": "some description",
-                        "directionCode": "%s",
-                        "movementDate": "%s",
-                        "movementTime": "%s",
-                        "movementReason": "some reason"
-                    }
-                
-        """.trimIndent(),
-        offenderNumber,
-        createDateTime,
-        if (directionCode == "IN") "ADM" else "REL",
-        directionCode,
-        movementDate,
-        movementTime,
-      )
+  fun stubGetMovementsByBooking(
+    bookingId: Long?,
+    response: String = """
+  [
+    {
+      "sequence": 10,
+      "fromAgency": "NHI",
+      "toAgency": "SHEFCC",
+      "movementType": "CRT",
+      "directionCode": "OUT",
+      "movementDateTime": "2023-02-10T08:11:00",
+      "movementReasonCode": "PR",
+      "createdDateTime": "2023-02-10T08:11:22.685037",
+      "modifiedDateTime": "2023-02-10T14:19:14.560498"
+    },
+    {
+      "sequence": 11,
+      "fromAgency": "NHI",
+      "toAgency": "SHEFCC",
+      "movementType": "CRT",
+      "directionCode": "OUT",
+      "movementDateTime": "2023-02-10T08:11:00",
+      "movementReasonCode": "PR",
+      "createdDateTime": "2023-02-10T08:11:22.685037",
+      "modifiedDateTime": "2023-02-10T14:19:14.560498"
+    },
+    {
+      "sequence": 12,
+      "fromAgency": "NHI",
+      "toAgency": "SHEFCC",
+      "movementType": "CRT",
+      "directionCode": "OUT",
+      "movementDateTime": "2023-02-10T08:11:00",
+      "movementReasonCode": "PR",
+      "createdDateTime": "2023-02-10T08:11:22.685037",
+      "modifiedDateTime": "2023-02-10T14:19:14.560498"
     }
-    stubFor(
-      WireMock.post("/api/movements/offenders?latestOnly=false&allBookings=true").willReturn(
-        WireMock.aResponse()
-          .withHeader("Content-Type", "application/json")
-          .withBody(
-            String.format(
-              """
-                        [
-                            %s
-                        ]
-                        
-              """.trimIndent(),
-              movements.stream().map(asJson).collect(Collectors.joining(",")),
-            ),
-          )
-          .withStatus(200),
-      ),
-    )
+  ]
+    """.trimIndent(),
+  ) {
+    stubFor(get(String.format("/api/movements/booking/%d", bookingId)).willReturn(okJson(response)))
   }
 
   private fun prisonerDetails(
@@ -140,10 +123,10 @@ class PrisonApiMockServer internal constructor() : WireMockServer(8086) {
     lastMovementReasonCode: String,
     status: String,
     latestLocationId: String,
-  ): String = String.format(
+  ): String =
     """
             {
-                "offenderNo": "%s",
+                "offenderNo": "$offenderNumber",
                 "bookingId": 1201233,
                 "bookingNo": "38559A",
                 "offenderId": 2582162,
@@ -189,12 +172,12 @@ class PrisonApiMockServer internal constructor() : WireMockServer(8086) {
                 "offenceHistory": [],
                 "sentenceTerms": [],
                 "aliases": [],
-                "status": "%s",
-                "statusReason": "ADM-N",
-                "lastMovementTypeCode": "%s",
-                "lastMovementReasonCode": "%s",
-                "legalStatus": "%s",
-                "recall": %b,
+                "status": "$status",
+                "statusReason": "$lastMovementTypeCode-$lastMovementReasonCode",
+                "lastMovementTypeCode": "$lastMovementTypeCode",
+                "lastMovementReasonCode": "$lastMovementReasonCode",
+                "legalStatus": "$legalStatus",
+                "recall": $recall,
                 "imprisonmentStatus": "TRL",
                 "imprisonmentStatusDescription": "Committed to Crown Court for Trial",
                 "privilegeSummary": {
@@ -207,18 +190,10 @@ class PrisonApiMockServer internal constructor() : WireMockServer(8086) {
                 },
                 "receptionDate": "2021-06-01",
                 "locationDescription": "Moorland (HMP & YOI)",
-                "latestLocationId": "%s"
+                "latestLocationId": "$latestLocationId"
             }
                         
-    """.trimIndent(),
-    offenderNumber,
-    status,
-    lastMovementTypeCode,
-    lastMovementReasonCode,
-    legalStatus,
-    recall,
-    latestLocationId,
-  )
+    """.trimIndent()
 
   private fun basicPrisonerDetails(offenderNumber: String, bookingId: Long?): String = String.format(
     """
@@ -253,7 +228,7 @@ class PrisonApiMockServer internal constructor() : WireMockServer(8086) {
             {"status": "down"}
     """.trimIndent()
     stubFor(
-      WireMock.get("/health/ping").willReturn(
+      get("/health/ping").willReturn(
         WireMock.aResponse()
           .withHeader("Content-Type", "application/json")
           .withBody(if (status == 200) up else down)
@@ -261,7 +236,4 @@ class PrisonApiMockServer internal constructor() : WireMockServer(8086) {
       ),
     )
   }
-
-  @JvmRecord
-  data class MovementFragment(val directionCode: String, val movementDateTime: LocalDateTime)
 }


### PR DESCRIPTION
Revise fix by populating the prison-offender-events.prisoner.received event with details from the actual movement rather than the latest movement